### PR TITLE
Implemented MagmaCoreObjectDatabase Queries

### DIFF
--- a/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreDatabase.java
+++ b/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreDatabase.java
@@ -65,9 +65,9 @@ public interface MagmaCoreDatabase {
     List<Thing> findByPredicateIri(IRI predicateIri, IRI objectIri);
 
     /**
-     * Find object(s) that have a specific predicate associated with them.
+     * Find object(s) that have a specific HQDM-defined predication.
      *
-     * @param predicateIri IRI of the predicate being queried.
+     * @param predicateIri IRI of the HQDM relationship type being queried.
      * @return The object(s).
      */
     List<Thing> findByPredicateIriOnly(HqdmIri predicateIri);

--- a/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreObjectDatabase.java
+++ b/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreObjectDatabase.java
@@ -94,7 +94,9 @@ public class MagmaCoreObjectDatabase implements MagmaCoreDatabase {
      */
     @Override
     public List<Thing> findByPredicateIriOnly(final HqdmIri predicateIri) {
-        throw new RuntimeException("findByPredicateIRIOnly not yet implemented.");
+        return objects.values().stream()
+                .filter(object -> object.hasValue(predicateIri))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -103,9 +105,7 @@ public class MagmaCoreObjectDatabase implements MagmaCoreDatabase {
     @Override
     public List<Thing> findByPredicateIriAndStringValue(final IRI predicateIri,
             final String value) {
-        return objects
-                .values()
-                .stream()
+        return objects.values().stream()
                 .filter(object -> object.hasThisStringValue(predicateIri, value))
                 .collect(Collectors.toList());
     }
@@ -116,8 +116,9 @@ public class MagmaCoreObjectDatabase implements MagmaCoreDatabase {
     @Override
     public List<Thing> findByPredicateIriAndStringCaseInsensitive(final IRI predicateIri,
             final String value) {
-        throw new RuntimeException(
-                "findByPredicateIRIAndStringCaseInsensitive not yet implemented.");
+        return objects.values().stream()
+                .filter(object -> object.hasThisStringValueIgnoreCase(predicateIri, value))
+                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
Resolves #4

Implemented `findByPredicateIriOnly` and `findByPredicateIriAndStringCaseInsensitive` queries in MagmaCoreObjectDatabase using the `hasValue` and `hasStringValueIgnoreCase` functions of `HqdmObject`.