### PR TITLE
Fix example query in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An introduction to Magma Core and the [HQDM Java object library](https://github.
 - To run Magma Core, run `mvn compile exec:java -Dexec.mainClass="uk.gov.gchq.magmacore.MagmaCore"`. This will execute the selected example method from the demo package. Alternatively, if you are using an IDE, you should be able to run the main method in MagmaCore.java from the editor.
 - To select which example to run, change the FusekiService.run() call in MagmaCore.java to the desired demo class in magmacore/demo. Each of these demos have slightly different behaviours, which are described in the code.
 - By default, this is set to the Fuseki server example, which will build and populate a Jena dataset hosted on a Fuseki server accessible at `localhost:3330/tdb`
-  - The dataset can then be queried via a web browser by going to `http://localhost:3330/tdb/sparql?query=?query=SELECT ?s ?p ?o WHERE {?s ?p ?o.}`
+  - The dataset can then be queried via a web browser by going to `http://localhost:3330/tdb/sparql?query=SELECT ?s ?p ?o WHERE {?s ?p ?o.}`
   - This can also be done via curl on the command line using: `curl -X POST -d "query=select ?s ?p ?o where { ?s ?p ?o . }" localhost:3330/tdb/query`
 
 ## Contributing


### PR DESCRIPTION
Removed the duplicate `?query=`  from the example in the README.