### PR TITLE
Add a remote SPARQL server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An introduction to Magma Core and the [HQDM Java object library](https://github.
 - To run Magma Core, run `mvn compile exec:java -Dexec.mainClass="uk.gov.gchq.magmacore.MagmaCore"`. This will execute the selected example method from the demo package. Alternatively, if you are using an IDE, you should be able to run the main method in MagmaCore.java from the editor.
 - To select which example to run, change the FusekiService.run() call in MagmaCore.java to the desired demo class in magmacore/demo. Each of these demos have slightly different behaviours, which are described in the code.
 - By default, this is set to the Fuseki server example, which will build and populate a Jena dataset hosted on a Fuseki server accessible at `localhost:3330/tdb`
-  - The dataset can then be queried via a web browser by going to `http://localhost:3330/tdb/sparql?query=?query=SELECT ?s ?p ?o WHERE {?s ?p ?o.}`
+  - The dataset can then be queried via a web browser by going to `http://localhost:3330/tdb/sparql?query=SELECT ?s ?p ?o WHERE {?s ?p ?o.}`
   - This can also be done via curl on the command line using: `curl -X POST -d "query=select ?s ?p ?o where { ?s ?p ?o . }" localhost:3330/tdb/query`
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ An introduction to Magma Core and the [HQDM Java object library](https://github.
 
 ## Setup
 
-- To run Magma Core, run `mvn compile exec:java -Dexec.mainClass="uk.gov.gchq.magmacore.MagmaCore"`. This will execute the selected example method from the demo package. Alternatively, if you are using an IDE, you should be able to run the main method in MagmaCore.java from the editor.
-- To select which example to run, change the FusekiService.run() call in MagmaCore.java to the desired demo class in magmacore/demo. Each of these demos have slightly different behaviours, which are described in the code.
-- By default, this is set to the Fuseki server example, which will build and populate a Jena dataset hosted on a Fuseki server accessible at `localhost:3330/tdb`
+- To run Magma Core, run `mvn compile exec:java -Dexec.mainClass="uk.gov.gchq.magmacore.MagmaCore"`. This will execute the fuseki example from the `demo` package. It will populate the database with example data if it is empty. The Fuseki server is accessible at `localhost:3330/tdb`
   - The dataset can then be queried via a web browser by going to `http://localhost:3330/tdb/sparql?query=SELECT ?s ?p ?o WHERE {?s ?p ?o.}`
   - This can also be done via curl on the command line using: `curl -X POST -d "query=select ?s ?p ?o where { ?s ?p ?o . }" localhost:3330/tdb/query`
+- You can also run the examples using `mvn compile exec:java -Dexec.mainClass="uk.gov.gchq.magmacore.MagmaCore" -Dexec.args=XXX` where XXX is one of:
+  - `fuseki` - same as no arguments except this does not populate the database with example data.
+  - `fuseki-populate` - same as no arguments.
+  - `remote` - connects to a local SPARQL endpoint on `http://localhost:3330/tdb`, i.e. the `fuseki` server if executed in a separate shell session.
+  - `remote-populate` - connects to a local SPARQL endpoint on `http://localhost:3330/tdb`, i.e. the `fuseki` server if executed in a separate shell session. It will populate the database with example data.
+  - `jena` - executes the Apache Jena database demo.
+  - `object` - executes the object database demo.
+- Alternatively, if you are using an IDE, you should be able to run the main method in MagmaCore.java from the editor.
 
 ## Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,13 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>uk.gov.gchq.magma-core</groupId>
   <artifactId>magma-core</artifactId>
-  <version>1.0</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Magma Core</name>
@@ -51,33 +52,33 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.4</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>apache-jena-libs</artifactId>
       <type>pom</type>
-      <version>4.0.0</version>
+      <version>4.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-fuseki-main</artifactId>
-      <version>4.0.0</version>
+      <version>4.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.15.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.15.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.14.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.gchq.hqdm</groupId>

--- a/src/main/java/uk/gov/gchq/magmacore/MagmaCore.java
+++ b/src/main/java/uk/gov/gchq/magmacore/MagmaCore.java
@@ -15,6 +15,8 @@
 package uk.gov.gchq.magmacore;
 
 import uk.gov.gchq.magmacore.demo.FusekiService;
+import uk.gov.gchq.magmacore.demo.JenaDatabaseDemo;
+import uk.gov.gchq.magmacore.demo.ObjectDatabaseDemo;
 import uk.gov.gchq.magmacore.demo.RemoteSparqlDatabaseDemo;
 
 /**
@@ -33,14 +35,20 @@ public final class MagmaCore {
         if (args.length == 0) {
             fuseki(true);
         } else {
-          if (args[0].equals("fuseki")) {
+          final String option = args[0];
+
+          if (option.equals("fuseki")) {
               fuseki(false);
-          } else if (args[0].equals("fuseki-populate")) {
+          } else if (option.equals("fuseki-populate")) {
               fuseki(true);
-          } else if (args[0].equals("remote")) {
+          } else if (option.equals("remote")) {
               remoteSparqlDatabaseDemo(false);
-          } else if (args[0].equals("remote-populate")) {
+          } else if (option.equals("remote-populate")) {
             remoteSparqlDatabaseDemo(true);
+          } else if (option.equals("jena")) {
+            jenaDemo();
+          } else if (option.equals("object")) {
+            objectDemo();
           }
         }
     }
@@ -61,5 +69,19 @@ public final class MagmaCore {
      */
     public static void remoteSparqlDatabaseDemo(final boolean populate) {
         new RemoteSparqlDatabaseDemo("http://localhost:3330/tdb").run(populate);
+    }
+
+    /**
+     * Executes the ObjectDatabaseDemo.
+     */
+    public static void objectDemo() {
+      new ObjectDatabaseDemo().run();
+    }
+
+    /**
+     * Executes the JenaDatabaseDemo.
+     */
+    public static void jenaDemo() {
+      new JenaDatabaseDemo().run();
     }
 }

--- a/src/main/java/uk/gov/gchq/magmacore/MagmaCore.java
+++ b/src/main/java/uk/gov/gchq/magmacore/MagmaCore.java
@@ -15,6 +15,7 @@
 package uk.gov.gchq.magmacore;
 
 import uk.gov.gchq.magmacore.demo.FusekiService;
+import uk.gov.gchq.magmacore.demo.RemoteSparqlDatabaseDemo;
 
 /**
  * Application entry point.
@@ -24,11 +25,41 @@ public final class MagmaCore {
     private MagmaCore() {}
 
     /**
-     * Executes FusekiService or selected database example.
+     * Executes the selected database example.
      *
      * @param args Application arguments.
      */
     public static void main(final String[] args) {
-        new FusekiService().run();
+        if (args.length == 0) {
+            fuseki(true);
+        } else {
+          if (args[0].equals("fuseki")) {
+              fuseki(false);
+          } else if (args[0].equals("fuseki-populate")) {
+              fuseki(true);
+          } else if (args[0].equals("remote")) {
+              remoteSparqlDatabaseDemo(false);
+          } else if (args[0].equals("remote-populate")) {
+            remoteSparqlDatabaseDemo(true);
+          }
+        }
+    }
+
+    /**
+     * Executes the FusekiService.
+     *
+     * @param populate true if the dataset should be populated with example data
+     */
+    public static void fuseki(final boolean populate) {
+        new FusekiService().run(populate);
+    }
+
+    /**
+     * Executes the RemoteSparqlDatabaseDemo.
+     *
+     * @param populate true if the dataset should be populated with example data
+     */
+    public static void remoteSparqlDatabaseDemo(final boolean populate) {
+        new RemoteSparqlDatabaseDemo("http://localhost:3330/tdb").run(populate);
     }
 }

--- a/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreRemoteSparqlDatabase.java
+++ b/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreRemoteSparqlDatabase.java
@@ -27,7 +27,6 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
-import org.apache.jena.query.TxnType;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
@@ -76,14 +75,9 @@ public class MagmaCoreRemoteSparqlDatabase implements MagmaCoreDatabase {
      * @param dataset the Dataset to be loaded into the database
      */
     public MagmaCoreRemoteSparqlDatabase(final String serviceUrl, final Dataset dataset) {
-      connection = RDFConnectionRemote.newBuilder()
-       .destination(serviceUrl)
-       .queryEndpoint("query")
-       .updateEndpoint("update")
-       .triplesFormat(RDFFormat.RDFJSON)
-       .build();
+        this(serviceUrl);
 
-       connection.load(dataset.getDefaultModel());
+        connection.load(dataset.getDefaultModel());
     }
 
     /**

--- a/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreRemoteSparqlDatabase.java
+++ b/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreRemoteSparqlDatabase.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2021 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package uk.gov.gchq.magmacore.database;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.jena.atlas.lib.Pair;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.rdfconnection.RDFConnection;
+import org.apache.jena.rdfconnection.RDFConnectionRemote;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.util.PrintUtil;
+
+import uk.gov.gchq.hqdm.iri.HqdmIri;
+import uk.gov.gchq.hqdm.iri.IRI;
+import uk.gov.gchq.hqdm.model.Thing;
+import uk.gov.gchq.hqdm.pojo.HqdmObjectFactory;
+import uk.gov.gchq.magmacore.query.QueryResult;
+import uk.gov.gchq.magmacore.query.QueryResultList;
+
+/**
+ * Connection to a remote SPARQL endpoint.
+ */
+public class MagmaCoreRemoteSparqlDatabase implements MagmaCoreDatabase {
+
+    private final RDFConnection connection;
+
+    /**
+     * Constructor to create a connection to a SPARQL endpoint.
+     *
+     * @param serviceUrl the URL String of the SPARQL update endpoint
+     */
+    public MagmaCoreRemoteSparqlDatabase(final String serviceUrl) {
+      connection = RDFConnectionRemote.newBuilder()
+       .destination(serviceUrl)
+       .queryEndpoint("query")
+       .updateEndpoint("update")
+       .triplesFormat(RDFFormat.RDFJSON)
+       .build();
+    }
+
+    /**
+     * Constructor to create a connection to a SPARQL endpoint and load it with a dataset.
+     *
+     * @param serviceUrl the URL String of the SPARQL update endpoint
+     * @param dataset the Dataset to be loaded into the database
+     */
+    public MagmaCoreRemoteSparqlDatabase(final String serviceUrl, final Dataset dataset) {
+      connection = RDFConnectionRemote.newBuilder()
+       .destination(serviceUrl)
+       .queryEndpoint("query")
+       .updateEndpoint("update")
+       .triplesFormat(RDFFormat.RDFJSON)
+       .build();
+
+       connection.load(dataset.getDefaultModel());
+    }
+
+    /**
+     * Drop all data from the dataset.
+     */
+    public void drop() {
+        final String drop = "drop all";
+        executeUpdate(drop);
+    }
+
+     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Thing get(final IRI iri) {
+
+        final String query =
+                String.format("SELECT (<%1$s> as ?s) ?p ?o WHERE {<%1$s> ?p ?o.}", iri.toString());
+        final QueryResultList list = executeQuery(query);
+        final List<Thing> objects = toTopObjects(list);
+
+        if (!objects.isEmpty()) {
+            return objects.get(0);
+        } else {
+            return null;
+        }
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void create(final Thing object) {
+
+        final Model model = ModelFactory.createDefaultModel();
+
+        final Resource resource =
+                model.createResource(object.getIri().toString());
+
+        object.getPredicates()
+                .forEach((iri,
+                        predicates) -> predicates.forEach(predicate -> resource.addProperty(
+                                model.createProperty(iri.toString()),
+                                predicate.toString())));
+        
+        connection.load(model);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update(final Thing object) {
+        delete(object);
+        create(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void delete(final Thing object) {
+        executeUpdate(String.format("delete data {%s}", object.toTriples()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Thing> findByPredicateIri(final IRI predicateIri, final IRI objectIri) {
+        final String query =
+                "SELECT ?s ?p ?o WHERE {?s ?p ?o. ?s <" + predicateIri.toString() + "> <"
+                        + objectIri.toString() + ">.}";
+        final QueryResultList list = executeQuery(query);
+        return toTopObjects(list);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Thing> findByPredicateIriOnly(final HqdmIri predicateIri) {
+        final String query =
+                "SELECT ?s ?p ?o WHERE {{select ?s ?p ?o where { ?s ?p ?o.}}{select ?s where {?s <"
+                        + predicateIri.toString() + "> ?o.}}}";
+        final QueryResultList list = executeQuery(query);
+        return toTopObjects(list);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Thing> findByPredicateIriAndStringValue(final IRI predicateIri,
+            final String value) {
+        final String query = "SELECT ?s ?p ?o WHERE { ?s ?p ?o.  ?s <" + predicateIri.toString()
+                + "> \"\"\"" + value + "\"\"\".}";
+        final QueryResultList list = executeQuery(query);
+        return toTopObjects(list);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Thing> findByPredicateIriAndStringCaseInsensitive(final IRI predicateIri,
+            final String value) {
+        final String query =
+                "SELECT ?s ?p ?o WHERE {{ SELECT ?s ?p ?o where { ?s ?p ?o.}}{select ?s where {?s <"
+                        + predicateIri.toString()
+                        + "> ?o. BIND(LCASE(?o) AS ?lcase) FILTER(?lcase= \"\"\"" + value
+                        + "\"\"\")}}}";
+        final QueryResultList list = executeQuery(query);
+        return toTopObjects(list);
+    }
+
+    /**
+     * Perform an update query on the dataset.
+     *
+     * @param statement SPARQL update query to execute.
+     */
+    protected void executeUpdate(final String statement) {
+
+        connection.update(statement);
+
+    }
+
+    /**
+     * Perform a SPARQL query on the dataset.
+     *
+     * @param sparqlQueryString SPARQL query to execute.
+     * @return Results of the query.
+     */
+    protected QueryResultList executeQuery(final String sparqlQueryString) {
+        final QueryExecution queryExec = connection.query(sparqlQueryString);
+        return getQueryResultList(queryExec);
+    }
+
+    /**
+     * Execute a SPARQL query and construct a list of HQDM objects from the resulting RDF triples.
+     *
+     * @param queryExec SPARQL query to execute.
+     * @return Results of the query.
+     */
+    private final QueryResultList getQueryResultList(final QueryExecution queryExec) {
+        final ResultSet resultSet = queryExec.execSelect();
+        final List<QueryResult> queryResults = new ArrayList<>();
+        final QueryResultList queryResultList =
+                new QueryResultList(resultSet.getResultVars(), queryResults);
+        while (resultSet.hasNext()) {
+            final QuerySolution querySolution = resultSet.next();
+            final Iterator<String> varNames = querySolution.varNames();
+            final QueryResult queryResult = new QueryResult();
+
+            while (varNames.hasNext()) {
+                final String varName = varNames.next();
+                final RDFNode node = querySolution.get(varName);
+                queryResult.set(varName, node);
+            }
+            queryResults.add(queryResult);
+        }
+        queryExec.close();
+        return queryResultList;
+    }
+
+    private final List<Thing> toTopObjects(final QueryResultList queryResultsList) {
+        final Map<String, List<Pair<String, String>>> objectMap = new HashMap<>();
+        final String subjectVarName = queryResultsList.getVarNames().get(0);
+        final String predicateVarName = queryResultsList.getVarNames().get(1);
+        final String objectVarName = queryResultsList.getVarNames().get(2);
+
+        // Create a map of the triples for each unique subject IRI
+        final List<QueryResult> queryResults = queryResultsList.getQueryResults();
+        queryResults.forEach(queryResult -> {
+            final String subjectValue = queryResult.get(subjectVarName).toString();
+            final String predicateValue = queryResult.get(predicateVarName).toString();
+            final String objectValue = queryResult.get(objectVarName).toString();
+
+            List<Pair<String, String>> dataModelObject = objectMap.get(subjectValue);
+            if (dataModelObject == null) {
+                dataModelObject = new ArrayList<>();
+                objectMap.put(subjectValue, dataModelObject);
+            }
+            dataModelObject.add(new Pair<>(predicateValue, objectValue));
+        });
+
+        return objectMap.entrySet().stream()
+                .map(entry -> HqdmObjectFactory.create(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void dump(final PrintStream out) {
+        final Dataset dataset = connection.fetchDataset();
+        final Model model = dataset.getDefaultModel();
+        final StmtIterator statements = model.listStatements();
+
+        while (statements.hasNext()) {
+            final Statement statement = statements.nextStatement();
+            out.println(" - " + PrintUtil.print(statement));
+        }
+    }
+
+    /**
+     * Dump the contents of the collection as text in specified RDF language.
+     *
+     * @param out Output stream to dump to.
+     * @param language RDF language syntax to output data as.
+     */
+    public final void dump(final PrintStream out, final Lang language) {
+        final Dataset dataset = connection.fetchDataset();
+        RDFDataMgr.write(out, dataset.getDefaultModel(), language);
+    }
+}

--- a/src/main/java/uk/gov/gchq/magmacore/demo/FusekiService.java
+++ b/src/main/java/uk/gov/gchq/magmacore/demo/FusekiService.java
@@ -42,14 +42,14 @@ public final class FusekiService {
     /**
      * Run the example Fuseki server.
      */
-    public void run() {
+    public void run(final boolean populate) {
         // Create/connect to persistent TDB.
         final MagmaCoreJenaDatabase tdb = new MagmaCoreJenaDatabase("tdb");
 
         // If TDB is not already populated create set of example data objects to
         // store in TDB.
         tdb.begin();
-        if (tdb.getDataset().isEmpty()) {
+        if (tdb.getDataset().isEmpty() && populate) {
             // Build example data objects Dataset.
             final Dataset objects = ExampleDataObjects.buildDataset();
 
@@ -60,11 +60,11 @@ public final class FusekiService {
             tdb.abort();
         }
         // Build and start Fuseki server.
-        final FusekiServer server = FusekiServer
-                .create()
-                .port(3330)
-                .add("/tdb", tdb.getDataset(), true).build();
         FusekiLogging.setLogging();
-        server.start();
+        FusekiServer
+            .create()
+            .port(3330)
+            .add("/tdb", tdb.getDataset(), true)
+            .start();
     }
 }

--- a/src/main/java/uk/gov/gchq/magmacore/demo/JenaDatabaseDemo.java
+++ b/src/main/java/uk/gov/gchq/magmacore/demo/JenaDatabaseDemo.java
@@ -63,7 +63,7 @@ public final class JenaDatabaseDemo {
 
         // Add example data objects to dataset.
         jenaDatabase.begin();
-        objects.forEach(object -> jenaDatabase.create(object));
+        objects.forEach(jenaDatabase::create);
         jenaDatabase.commit();
 
         // Query database to check its populated.

--- a/src/main/java/uk/gov/gchq/magmacore/demo/RemoteSparqlDatabaseDemo.java
+++ b/src/main/java/uk/gov/gchq/magmacore/demo/RemoteSparqlDatabaseDemo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package uk.gov.gchq.magmacore.demo;
+
+import org.apache.jena.query.Dataset;
+
+import uk.gov.gchq.magmacore.database.MagmaCoreDatabase;
+import uk.gov.gchq.magmacore.database.MagmaCoreRemoteSparqlDatabase;
+
+/**
+ * Example use-case scenario for using a {@link MagmaCoreRemoteSparqlDatabase} with a remote service.
+ */
+public final class RemoteSparqlDatabaseDemo {
+
+    private final String url;
+
+    public RemoteSparqlDatabaseDemo(final String url) {
+      this.url = url;
+    }
+
+    /**
+     * Run the demo.
+     */
+    public void run(final boolean populate) {
+        final MagmaCoreDatabase db;
+
+        if (populate) {
+            final Dataset dataset = ExampleDataObjects.buildDataset();
+            db = new MagmaCoreRemoteSparqlDatabase(url, dataset);
+        } else {
+            db = new MagmaCoreRemoteSparqlDatabase(url);
+        }
+
+        db.dump(System.out);
+    }
+
+}


### PR DESCRIPTION
Changes:
1. Updated the version to `1.1-SNAPSHOT` - feel free to change this.
1. Updated the dependencies to the latest versions.
2. Added an example for accessing a remote SPARQL service using an `RDFConnection`.
3. Updated the `main` method to allow an example to be selected by a command-line parameter rather than needing a code change.
4. If no parameter is supplied then the default behaviour is the same as before.
5. Updated the README to explain how to user the command line parameter.

To try the remote example, first run MagmaCore with no parameters to start and populate a Fuseki instance, then in a separate shell execute `mvn compile exec:java -Dexec.mainClass="uk.gov.gchq.magmacore.MagmaCore" -Dexec.args=remote` which will dump the contents of the MagmaCore Fuseki instance. 