### PR TITLE
Fix issue with storing IRIs as Strings 

### DIFF
--- a/core/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreJenaDatabase.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/database/MagmaCoreJenaDatabase.java
@@ -29,6 +29,7 @@ import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
@@ -165,10 +166,19 @@ public class MagmaCoreJenaDatabase implements MagmaCoreDatabase {
      */
     @Override
     public void create(final Thing object) {
-        final Resource resource = dataset.getDefaultModel().createResource(object.getId());
+        final Model defaultModel = dataset.getDefaultModel();
 
-        object.getPredicates().forEach((iri, predicates) -> predicates.forEach(predicate -> resource
-                .addProperty(dataset.getDefaultModel().createProperty(iri.toString()), predicate.toString())));
+        final Resource resource = defaultModel.createResource(object.getId());
+
+        object.getPredicates()
+                .forEach((iri, predicates) -> predicates.forEach(value -> {
+                    if (value instanceof IRI) {
+                        final Resource valueResource = defaultModel.createResource(value.toString());
+                        resource.addProperty(defaultModel.createProperty(iri.toString()), valueResource);
+                    } else {
+                        resource.addProperty(defaultModel.createProperty(iri.toString()), value.toString());
+                    }
+                }));
     }
 
     /**
@@ -283,27 +293,38 @@ public class MagmaCoreJenaDatabase implements MagmaCoreDatabase {
     }
 
     private final List<Thing> toTopObjects(final QueryResultList queryResultsList) {
-        final Map<String, List<Pair<String, String>>> objectMap = new HashMap<>();
-        final String subjectVarName = ((List<String>) queryResultsList.getVarNames()).get(0);
-        final String predicateVarName = ((List<String>) queryResultsList.getVarNames()).get(1);
-        final String objectVarName = ((List<String>) queryResultsList.getVarNames()).get(2);
+        final Map<RDFNode, List<Pair<Object, Object>>> objectMap = new HashMap<>();
+        final List<String> varNames = (List<String>) queryResultsList.getVarNames();
+
+        final String subjectVarName = varNames.get(0);
+        final String predicateVarName = varNames.get(1);
+        final String objectVarName = varNames.get(2);
 
         // Create a map of the triples for each unique subject IRI
         final List<QueryResult> queryResults = queryResultsList.getQueryResults();
         queryResults.forEach(queryResult -> {
-            final String subjectValue = queryResult.get(subjectVarName).toString();
-            final String predicateValue = queryResult.get(predicateVarName).toString();
-            final String objectValue = queryResult.get(objectVarName).toString();
+            final RDFNode subjectValue = queryResult.get(subjectVarName);
+            final RDFNode predicateValue = queryResult.get(predicateVarName);
+            final RDFNode objectValue = queryResult.get(objectVarName);
 
-            List<Pair<String, String>> dataModelObject = objectMap.get(subjectValue);
+            List<Pair<Object, Object>> dataModelObject = objectMap.get(subjectValue);
             if (dataModelObject == null) {
                 dataModelObject = new ArrayList<>();
                 objectMap.put(subjectValue, dataModelObject);
             }
-            dataModelObject.add(new Pair<>(predicateValue, objectValue));
+            if (objectValue instanceof Literal) {
+                dataModelObject.add(new Pair<>(new IRI(predicateValue.toString()), objectValue.toString()));
+            } else if (objectValue instanceof Resource) {
+                dataModelObject.add(new Pair<>(new IRI(predicateValue.toString()), new IRI(objectValue.toString())));
+            } else {
+                throw new RuntimeException("objectValue is of unknown type: " + objectValue.getClass());
+            }
         });
 
-        return objectMap.entrySet().stream().map(entry -> HqdmObjectFactory.create(entry.getKey(), entry.getValue()))
+        return objectMap
+                .entrySet()
+                .stream()
+                .map(entry -> HqdmObjectFactory.create(new IRI(entry.getKey().toString()), entry.getValue()))
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/uk/gov/gchq/magmacore/service/transformation/DbCreateOperation.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/transformation/DbCreateOperation.java
@@ -34,16 +34,16 @@ public class DbCreateOperation implements Function<MagmaCoreService, MagmaCoreSe
     private IRI predicate;
 
     // The value of the property we're referring to.
-    private String object;
+    private Object object;
 
     /**
      * Constructs a DbCreateOperation to create a predicate.
      *
      * @param subject   Subject {@link IRI}.
      * @param predicate Predicate {@link IRI}.
-     * @param object    {@link String} value.
+     * @param object    {@link Object} value.
      */
-    public DbCreateOperation(final IRI subject, final IRI predicate, final String object) {
+    public DbCreateOperation(final IRI subject, final IRI predicate, final Object object) {
         this.subject = subject;
         this.predicate = predicate;
         this.object = object;
@@ -58,11 +58,11 @@ public class DbCreateOperation implements Function<MagmaCoreService, MagmaCoreSe
 
         if (thing == null) {
             final Thing newThing = SpatioTemporalExtentServices.createThing(subject.getIri());
-            newThing.addStringValue(predicate.getIri(), object);
+            newThing.addValue(predicate, object);
             mcService.create(newThing);
         } else {
-            if (!thing.hasThisValue(predicate.getIri(), object)) {
-                thing.addValue(predicate.getIri(), object);
+            if (!thing.hasThisValue(predicate, object)) {
+                thing.addValue(predicate, object);
                 mcService.update(thing);
             } else {
                 throw new DbTransformationException(

--- a/core/src/main/java/uk/gov/gchq/magmacore/service/transformation/DbDeleteOperation.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/transformation/DbDeleteOperation.java
@@ -27,16 +27,16 @@ import uk.gov.gchq.magmacore.service.MagmaCoreService;
 public class DbDeleteOperation implements Function<MagmaCoreService, MagmaCoreService> {
     private IRI subject;
     private IRI predicate;
-    private String object;
+    private Object object;
 
     /**
      * Constructs a DbDeleteOperation to delete a predicate.
      *
      * @param subject   Subject {@link IRI}.
      * @param predicate Predicate {@link IRI}.
-     * @param object    {@link String} value.
+     * @param object    {@link Object} value.
      */
-    public DbDeleteOperation(final IRI subject, final IRI predicate, final String object) {
+    public DbDeleteOperation(final IRI subject, final IRI predicate, final Object object) {
         this.subject = subject;
         this.predicate = predicate;
         this.object = object;
@@ -48,8 +48,8 @@ public class DbDeleteOperation implements Function<MagmaCoreService, MagmaCoreSe
     public MagmaCoreService apply(final MagmaCoreService mcService) {
         final Thing thing = mcService.get(subject);
 
-        if (thing != null && thing.hasThisValue(predicate.getIri(), object)) {
-            thing.removeValue(predicate.getIri(), object);
+        if (thing != null && thing.hasThisValue(predicate, object)) {
+            thing.removeValue(predicate, object);
             mcService.update(thing);
             return mcService;
         }

--- a/core/src/test/java/uk/gov/gchq/magmacore/service/transformation/DbChangeSetTest.java
+++ b/core/src/test/java/uk/gov/gchq/magmacore/service/transformation/DbChangeSetTest.java
@@ -46,10 +46,13 @@ public class DbChangeSetTest {
 
         // Create operations to add an object with dummy values.
         final IRI individualIri = new IRI(TEST_BASE, "individual");
+        final IRI classOfIndividualIri = new IRI(TEST_BASE, "classOfIndividual");
+        final IRI possibleWorldIri = new IRI(TEST_BASE, "possible_world");
+
         final DbChangeSet createIndividual = new DbChangeSet(List.of(),
-                List.of(new DbCreateOperation(individualIri, RDFS.RDF_TYPE, HQDM.INDIVIDUAL.getIri()),
-                        new DbCreateOperation(individualIri, HQDM.MEMBER_OF, "classOfIndividual"),
-                        new DbCreateOperation(individualIri, HQDM.PART_OF_POSSIBLE_WORLD, "possible world")));
+                List.of(new DbCreateOperation(individualIri, RDFS.RDF_TYPE, HQDM.INDIVIDUAL),
+                        new DbCreateOperation(individualIri, HQDM.MEMBER_OF, classOfIndividualIri),
+                        new DbCreateOperation(individualIri, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorldIri)));
 
         // Apply the operations to the dataset.
         mcService.runInTransaction(createIndividual);
@@ -58,9 +61,9 @@ public class DbChangeSetTest {
         final Thing individual = mcService.getInTransaction(individualIri);
 
         assertNotNull(individual);
-        assertTrue(individual.hasThisValue(RDFS.RDF_TYPE.getIri(), HQDM.INDIVIDUAL.getIri()));
-        assertTrue(individual.hasThisValue(HQDM.MEMBER_OF.getIri(), "classOfIndividual"));
-        assertTrue(individual.hasThisValue(HQDM.PART_OF_POSSIBLE_WORLD.getIri(), "possible world"));
+        assertTrue(individual.hasThisValue(RDFS.RDF_TYPE, HQDM.INDIVIDUAL));
+        assertTrue(individual.hasThisValue(HQDM.MEMBER_OF, classOfIndividualIri));
+        assertTrue(individual.hasThisValue(HQDM.PART_OF_POSSIBLE_WORLD, possibleWorldIri));
 
         // Invert the operations and apply them in reverse order.
         mcService.runInTransaction(DbChangeSet.invert(createIndividual));

--- a/core/src/test/java/uk/gov/gchq/magmacore/service/transformation/DbOperationTest.java
+++ b/core/src/test/java/uk/gov/gchq/magmacore/service/transformation/DbOperationTest.java
@@ -48,11 +48,12 @@ public class DbOperationTest {
 
         // Create an operation to add an object with dummy values.
         final IRI individualIri = new IRI(TEST_BASE, "individual");
+        final IRI classOfIndividualIri = new IRI(TEST_BASE, "classOfIndividual");
 
         final DbCreateOperation createIndividual = new DbCreateOperation(individualIri, RDFS.RDF_TYPE,
-                HQDM.INDIVIDUAL.getIri());
+                HQDM.INDIVIDUAL);
         final DbCreateOperation createIndividualMemberOf = new DbCreateOperation(individualIri, HQDM.MEMBER_OF,
-                "classOfIndividual");
+                classOfIndividualIri);
 
         // Apply the operations.
         mcService.runInTransaction(createIndividual);
@@ -62,13 +63,13 @@ public class DbOperationTest {
         final Thing individual = mcService.getInTransaction(individualIri);
 
         assertNotNull(individual);
-        assertTrue(individual.hasThisValue(RDFS.RDF_TYPE.getIri(), HQDM.INDIVIDUAL.getIri()));
+        assertTrue(individual.hasThisValue(RDFS.RDF_TYPE, HQDM.INDIVIDUAL));
 
         // Invert the operation and assert that it is no longer present.
         mcService.runInTransaction(DbCreateOperation.invert(createIndividualMemberOf));
 
         final Thing individualFromDb = mcService.getInTransaction(individualIri);
-        assertFalse(individualFromDb.hasThisValue(HQDM.MEMBER_OF.getIri(), "classOfIndividual"));
+        assertFalse(individualFromDb.hasThisValue(HQDM.MEMBER_OF, classOfIndividualIri));
     }
 
     /**
@@ -83,7 +84,7 @@ public class DbOperationTest {
 
         // Create operations to create an object.
         final DbCreateOperation createIndividual = new DbCreateOperation(individualIri, RDFS.RDF_TYPE,
-                HQDM.INDIVIDUAL.getIri());
+                HQDM.INDIVIDUAL);
         final DbCreateOperation createIndividualMemberOf = new DbCreateOperation(individualIri, HQDM.MEMBER_OF,
                 "classOfIndividual");
         final DbCreateOperation createIndividualPartOfPossibleWorld = new DbCreateOperation(individualIri,
@@ -98,9 +99,9 @@ public class DbOperationTest {
         final Thing individual = mcService.getInTransaction(individualIri);
 
         assertNotNull(individual);
-        assertTrue(individual.hasThisValue(RDFS.RDF_TYPE.getIri(), HQDM.INDIVIDUAL.getIri()));
-        assertTrue(individual.hasThisValue(HQDM.MEMBER_OF.getIri(), "classOfIndividual"));
-        assertTrue(individual.hasThisValue(HQDM.PART_OF_POSSIBLE_WORLD.getIri(), "possible world"));
+        assertTrue(individual.hasThisValue(RDFS.RDF_TYPE, HQDM.INDIVIDUAL));
+        assertTrue(individual.hasThisValue(HQDM.MEMBER_OF, "classOfIndividual"));
+        assertTrue(individual.hasThisValue(HQDM.PART_OF_POSSIBLE_WORLD, "possible world"));
 
         // Invert two of the operations, apply them in reverse order and assert they are no longer present.
         mcService.runInTransaction(DbCreateOperation.invert(createIndividualPartOfPossibleWorld));
@@ -122,7 +123,7 @@ public class DbOperationTest {
 
         // Create an operation to add an object with dummy values.
         final DbCreateOperation createIndividual = new DbCreateOperation(individualIri, RDFS.RDF_TYPE,
-                HQDM.INDIVIDUAL.getIri());
+                HQDM.INDIVIDUAL);
 
         // Apply the operation twice, the second should throw an exception.
         mcService.runInTransaction(createIndividual);

--- a/core/src/test/java/uk/gov/gchq/magmacore/service/transformation/DbTransformationTest.java
+++ b/core/src/test/java/uk/gov/gchq/magmacore/service/transformation/DbTransformationTest.java
@@ -46,17 +46,20 @@ public class DbTransformationTest {
 
         final IRI individualIri = new IRI(TEST_BASE, "individual");
         final IRI personIri = new IRI(TEST_BASE, "person");
+        final IRI classOfIndividualIri = new IRI(TEST_BASE, "classOfIndividual");
+        final IRI classOfPersonIri = new IRI(TEST_BASE, "classOfPerson");
+        final IRI possibleWorldIri = new IRI(TEST_BASE, "possible_world");
 
         // Create operations to add an object with dummy values.
         final DbChangeSet createIndividual = new DbChangeSet(List.of(),
-                List.of(new DbCreateOperation(individualIri, RDFS.RDF_TYPE, HQDM.INDIVIDUAL.getIri()),
-                        new DbCreateOperation(individualIri, HQDM.MEMBER_OF, "classOfIndividual"),
-                        new DbCreateOperation(individualIri, HQDM.PART_OF_POSSIBLE_WORLD, "possible world")));
+                List.of(new DbCreateOperation(individualIri, RDFS.RDF_TYPE, HQDM.INDIVIDUAL),
+                        new DbCreateOperation(individualIri, HQDM.MEMBER_OF, classOfIndividualIri),
+                        new DbCreateOperation(individualIri, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorldIri)));
 
         final DbChangeSet createPerson = new DbChangeSet(List.of(),
-                List.of(new DbCreateOperation(personIri, RDFS.RDF_TYPE, HQDM.PERSON.getIri()),
-                        new DbCreateOperation(personIri, HQDM.MEMBER_OF, "classOfPerson"),
-                        new DbCreateOperation(personIri, HQDM.PART_OF_POSSIBLE_WORLD, "possible world")));
+                List.of(new DbCreateOperation(personIri, RDFS.RDF_TYPE, HQDM.PERSON),
+                        new DbCreateOperation(personIri, HQDM.MEMBER_OF, classOfPersonIri),
+                        new DbCreateOperation(personIri, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorldIri)));
 
         final DbTransformation transformation = new DbTransformation(List.of(createIndividual, createPerson));
 
@@ -67,16 +70,16 @@ public class DbTransformationTest {
         final Thing individual = mcService.getInTransaction(individualIri);
 
         assertNotNull(individual);
-        assertTrue(individual.hasThisValue(RDFS.RDF_TYPE.getIri(), HQDM.INDIVIDUAL.getIri()));
-        assertTrue(individual.hasThisValue(HQDM.MEMBER_OF.getIri(), "classOfIndividual"));
-        assertTrue(individual.hasThisValue(HQDM.PART_OF_POSSIBLE_WORLD.getIri(), "possible world"));
+        assertTrue(individual.hasThisValue(RDFS.RDF_TYPE, HQDM.INDIVIDUAL));
+        assertTrue(individual.hasThisValue(HQDM.MEMBER_OF, classOfIndividualIri));
+        assertTrue(individual.hasThisValue(HQDM.PART_OF_POSSIBLE_WORLD, possibleWorldIri));
 
         final Thing person = mcService.getInTransaction(personIri);
 
         assertNotNull(person);
-        assertTrue(person.hasThisValue(RDFS.RDF_TYPE.getIri(), HQDM.PERSON.getIri()));
-        assertTrue(person.hasThisValue(HQDM.MEMBER_OF.getIri(), "classOfPerson"));
-        assertTrue(person.hasThisValue(HQDM.PART_OF_POSSIBLE_WORLD.getIri(), "possible world"));
+        assertTrue(person.hasThisValue(RDFS.RDF_TYPE, HQDM.PERSON));
+        assertTrue(person.hasThisValue(HQDM.MEMBER_OF, classOfPersonIri));
+        assertTrue(person.hasThisValue(HQDM.PART_OF_POSSIBLE_WORLD, possibleWorldIri));
 
         // Invert the operations, apply them in reverse order and assert they are no longer present.
         mcService.runInTransaction(transformation.invert());

--- a/examples/src/main/java/uk/gov/gchq/magmacore/examples/data/ExampleAssociations.java
+++ b/examples/src/main/java/uk/gov/gchq/magmacore/examples/data/ExampleAssociations.java
@@ -80,47 +80,52 @@ public class ExampleAssociations {
         final IRI houseOccupiedAssociation = new IRI(USER_BASE, uid());
 
         // Create DbCreateOperations to create the objects and their properties.
-        creates.add(new DbCreateOperation(personState, RDFS.RDF_TYPE, HQDM.STATE_OF_PERSON.getIri()));
-        creates.add(new DbCreateOperation(personState, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
-        creates.add(new DbCreateOperation(personState, HQDM.MEMBER_OF, classOfStateOfPerson.getId()));
-        creates.add(new DbCreateOperation(personState, HQDM.TEMPORAL_PART_OF, person.getId()));
-        creates.add(new DbCreateOperation(personState, HQDM.BEGINNING, beginning.getIri()));
-        creates.add(new DbCreateOperation(personState, HQDM.ENDING, ending.getIri()));
+        creates.add(new DbCreateOperation(personState, RDFS.RDF_TYPE, HQDM.STATE_OF_PERSON));
+        creates.add(new DbCreateOperation(personState, HQDM.PART_OF_POSSIBLE_WORLD, new IRI(possibleWorld.getId())));
+        creates.add(new DbCreateOperation(personState, HQDM.MEMBER_OF, new IRI(classOfStateOfPerson.getId())));
+        creates.add(new DbCreateOperation(personState, HQDM.TEMPORAL_PART_OF, new IRI(person.getId())));
+        creates.add(new DbCreateOperation(personState, HQDM.BEGINNING, beginning));
+        creates.add(new DbCreateOperation(personState, HQDM.ENDING, ending));
 
-        creates.add(new DbCreateOperation(houseState, RDFS.RDF_TYPE, HQDM.STATE_OF_FUNCTIONAL_SYSTEM.getIri()));
-        creates.add(new DbCreateOperation(houseState, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
+        creates.add(new DbCreateOperation(houseState, RDFS.RDF_TYPE, HQDM.STATE_OF_FUNCTIONAL_SYSTEM));
+        creates.add(new DbCreateOperation(houseState, HQDM.PART_OF_POSSIBLE_WORLD, new IRI(possibleWorld.getId())));
         creates.add(new DbCreateOperation(houseState, HQDM.MEMBER_OF,
-                classOfStateOfFunctionalSystemDomesticProperty.getId()));
-        creates.add(new DbCreateOperation(houseState, HQDM.TEMPORAL_PART_OF, house.getId()));
-        creates.add(new DbCreateOperation(houseState, HQDM.BEGINNING, beginning.getIri()));
-        creates.add(new DbCreateOperation(houseState, HQDM.ENDING, ending.getIri()));
+                new IRI(classOfStateOfFunctionalSystemDomesticProperty.getId())));
+        creates.add(new DbCreateOperation(houseState, HQDM.TEMPORAL_PART_OF, new IRI(house.getId())));
+        creates.add(new DbCreateOperation(houseState, HQDM.BEGINNING, beginning));
+        creates.add(new DbCreateOperation(houseState, HQDM.ENDING, ending));
 
-        creates.add(new DbCreateOperation(personParticipant, RDFS.RDF_TYPE, HQDM.PARTICIPANT.getIri()));
-        creates.add(new DbCreateOperation(personParticipant, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
-        creates.add(new DbCreateOperation(personParticipant, HQDM.MEMBER_OF_KIND, occupierOfPropertyRole.getId()));
-        creates.add(new DbCreateOperation(personParticipant, HQDM.TEMPORAL_PART_OF, personState.getIri()));
-        creates.add(new DbCreateOperation(personParticipant, HQDM.BEGINNING, beginning.getIri()));
-        creates.add(new DbCreateOperation(personParticipant, HQDM.ENDING, ending.getIri()));
-
-        creates.add(new DbCreateOperation(houseParticipant, RDFS.RDF_TYPE, HQDM.PARTICIPANT.getIri()));
-        creates.add(new DbCreateOperation(houseParticipant, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
+        creates.add(new DbCreateOperation(personParticipant, RDFS.RDF_TYPE, HQDM.PARTICIPANT));
         creates.add(
-                new DbCreateOperation(houseParticipant, HQDM.MEMBER_OF_KIND, domesticOccupantInPropertyRole.getId()));
-        creates.add(new DbCreateOperation(houseParticipant, HQDM.TEMPORAL_PART_OF, houseState.getIri()));
-        creates.add(new DbCreateOperation(houseParticipant, HQDM.BEGINNING, beginning.getIri()));
-        creates.add(new DbCreateOperation(houseParticipant, HQDM.ENDING, ending.getIri()));
-
-        creates.add(new DbCreateOperation(houseOccupiedAssociation, RDFS.RDF_TYPE, HQDM.ASSOCIATION.getIri()));
+                new DbCreateOperation(personParticipant, HQDM.PART_OF_POSSIBLE_WORLD, new IRI(possibleWorld.getId())));
         creates.add(
-                new DbCreateOperation(houseOccupiedAssociation, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
+                new DbCreateOperation(personParticipant, HQDM.MEMBER_OF_KIND, new IRI(occupierOfPropertyRole.getId())));
+        creates.add(new DbCreateOperation(personParticipant, HQDM.TEMPORAL_PART_OF, personState));
+        creates.add(new DbCreateOperation(personParticipant, HQDM.BEGINNING, beginning));
+        creates.add(new DbCreateOperation(personParticipant, HQDM.ENDING, ending));
+
+        creates.add(new DbCreateOperation(houseParticipant, RDFS.RDF_TYPE, HQDM.PARTICIPANT));
+        creates.add(
+                new DbCreateOperation(houseParticipant, HQDM.PART_OF_POSSIBLE_WORLD, new IRI(possibleWorld.getId())));
+        creates.add(
+                new DbCreateOperation(houseParticipant, HQDM.MEMBER_OF_KIND,
+                        new IRI(domesticOccupantInPropertyRole.getId())));
+        creates.add(new DbCreateOperation(houseParticipant, HQDM.TEMPORAL_PART_OF, houseState));
+        creates.add(new DbCreateOperation(houseParticipant, HQDM.BEGINNING, beginning));
+        creates.add(new DbCreateOperation(houseParticipant, HQDM.ENDING, ending));
+
+        creates.add(new DbCreateOperation(houseOccupiedAssociation, RDFS.RDF_TYPE, HQDM.ASSOCIATION));
+        creates.add(
+                new DbCreateOperation(houseOccupiedAssociation, HQDM.PART_OF_POSSIBLE_WORLD,
+                        new IRI(possibleWorld.getId())));
         creates.add(new DbCreateOperation(houseOccupiedAssociation, HQDM.MEMBER_OF_KIND,
-                occupantInPropertyKindOfAssociation.getId()));
+                new IRI(occupantInPropertyKindOfAssociation.getId())));
         creates.add(new DbCreateOperation(houseOccupiedAssociation, HQDM.CONSISTS_OF_PARTICIPANT,
-                houseParticipant.getIri()));
+                houseParticipant));
         creates.add(new DbCreateOperation(houseOccupiedAssociation, HQDM.CONSISTS_OF_PARTICIPANT,
-                personParticipant.getIri()));
-        creates.add(new DbCreateOperation(houseOccupiedAssociation, HQDM.BEGINNING, beginning.getIri()));
-        creates.add(new DbCreateOperation(houseOccupiedAssociation, HQDM.ENDING, ending.getIri()));
+                personParticipant));
+        creates.add(new DbCreateOperation(houseOccupiedAssociation, HQDM.BEGINNING, beginning));
+        creates.add(new DbCreateOperation(houseOccupiedAssociation, HQDM.ENDING, ending));
     }
 
     /**
@@ -149,20 +154,20 @@ public class ExampleAssociations {
 
         // Create DbCreateOperations to create the objects and their properties.
         final List<DbCreateOperation> creates = new ArrayList<DbCreateOperation>();
-        creates.add(new DbCreateOperation(event1, RDFS.RDF_TYPE, HQDM.EVENT.getIri()));
-        creates.add(new DbCreateOperation(event1, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
+        creates.add(new DbCreateOperation(event1, RDFS.RDF_TYPE, HQDM.EVENT));
+        creates.add(new DbCreateOperation(event1, HQDM.PART_OF_POSSIBLE_WORLD, new IRI(possibleWorld.getId())));
         creates.add(new DbCreateOperation(event1, HQDM.ENTITY_NAME, "2020-08-15T17:50:00"));
 
-        creates.add(new DbCreateOperation(event2, RDFS.RDF_TYPE, HQDM.EVENT.getIri()));
-        creates.add(new DbCreateOperation(event2, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
+        creates.add(new DbCreateOperation(event2, RDFS.RDF_TYPE, HQDM.EVENT));
+        creates.add(new DbCreateOperation(event2, HQDM.PART_OF_POSSIBLE_WORLD, new IRI(possibleWorld.getId())));
         creates.add(new DbCreateOperation(event2, HQDM.ENTITY_NAME, "2020-08-15T19:21:00"));
 
-        creates.add(new DbCreateOperation(event3, RDFS.RDF_TYPE, HQDM.EVENT.getIri()));
-        creates.add(new DbCreateOperation(event3, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
+        creates.add(new DbCreateOperation(event3, RDFS.RDF_TYPE, HQDM.EVENT));
+        creates.add(new DbCreateOperation(event3, HQDM.PART_OF_POSSIBLE_WORLD, new IRI(possibleWorld.getId())));
         creates.add(new DbCreateOperation(event3, HQDM.ENTITY_NAME, "2020-08-16T22:33:00"));
 
-        creates.add(new DbCreateOperation(event4, RDFS.RDF_TYPE, HQDM.EVENT.getIri()));
-        creates.add(new DbCreateOperation(event4, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getId()));
+        creates.add(new DbCreateOperation(event4, RDFS.RDF_TYPE, HQDM.EVENT));
+        creates.add(new DbCreateOperation(event4, HQDM.PART_OF_POSSIBLE_WORLD, new IRI(possibleWorld.getId())));
         creates.add(new DbCreateOperation(event4, HQDM.ENTITY_NAME, "2020-08-17T10:46:00"));
 
         // Add more DbCreateOperations to create the required associations.

--- a/examples/src/main/java/uk/gov/gchq/magmacore/examples/data/ExampleIndividuals.java
+++ b/examples/src/main/java/uk/gov/gchq/magmacore/examples/data/ExampleIndividuals.java
@@ -64,30 +64,31 @@ public class ExampleIndividuals {
 
         // Create DbCreateOperations to create the objects and their properties.
         final List<DbCreateOperation> creates = List.of(
-                new DbCreateOperation(possibleWorld, RDFS.RDF_TYPE, HQDM.POSSIBLE_WORLD.getIri()),
+                new DbCreateOperation(possibleWorld, RDFS.RDF_TYPE, HQDM.POSSIBLE_WORLD),
                 new DbCreateOperation(possibleWorld, HQDM.ENTITY_NAME, "Example1_World"),
 
-                new DbCreateOperation(startEvent, RDFS.RDF_TYPE, HQDM.EVENT.getIri()),
-                new DbCreateOperation(startEvent, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(startEvent, RDFS.RDF_TYPE, HQDM.EVENT),
+                new DbCreateOperation(startEvent, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
                 new DbCreateOperation(startEvent, HQDM.ENTITY_NAME, "1991-02-18T00:00:00"),
 
-                new DbCreateOperation(endEvent, RDFS.RDF_TYPE, HQDM.EVENT.getIri()),
-                new DbCreateOperation(endEvent, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(endEvent, RDFS.RDF_TYPE, HQDM.EVENT),
+                new DbCreateOperation(endEvent, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
                 new DbCreateOperation(endEvent, HQDM.ENTITY_NAME, "1972-06-01T00:00:00"),
 
-                new DbCreateOperation(person, RDFS.RDF_TYPE, HQDM.PERSON.getIri()),
-                new DbCreateOperation(person, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(person, RDFS.RDF_TYPE, HQDM.PERSON),
+                new DbCreateOperation(person, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
                 new DbCreateOperation(person, HQDM.ENTITY_NAME, "PersonB1_Bob"),
-                new DbCreateOperation(person, HQDM.MEMBER_OF_KIND, kindOfPerson.getId()),
-                new DbCreateOperation(person, HQDM.NATURAL_ROLE, personRole.getId()),
-                new DbCreateOperation(person, HQDM.BEGINNING, startEvent.getIri()),
+                new DbCreateOperation(person, HQDM.MEMBER_OF_KIND, new IRI(kindOfPerson.getId())),
+                new DbCreateOperation(person, HQDM.NATURAL_ROLE, new IRI(personRole.getId())),
+                new DbCreateOperation(person, HQDM.BEGINNING, startEvent),
 
-                new DbCreateOperation(house, RDFS.RDF_TYPE, HQDM.FUNCTIONAL_SYSTEM.getIri()),
-                new DbCreateOperation(house, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(house, RDFS.RDF_TYPE, HQDM.FUNCTIONAL_SYSTEM),
+                new DbCreateOperation(house, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
                 new DbCreateOperation(house, HQDM.ENTITY_NAME, "HouseB"),
-                new DbCreateOperation(house, HQDM.MEMBER_OF_KIND, kindOfFunctionalSystemDomesticProperty.getId()),
-                new DbCreateOperation(house, HQDM.INTENDED_ROLE, domesticPropertyRole.getId()),
-                new DbCreateOperation(house, HQDM.BEGINNING, endEvent.getIri()));
+                new DbCreateOperation(house, HQDM.MEMBER_OF_KIND,
+                        new IRI(kindOfFunctionalSystemDomesticProperty.getId())),
+                new DbCreateOperation(house, HQDM.INTENDED_ROLE, new IRI(domesticPropertyRole.getId())),
+                new DbCreateOperation(house, HQDM.BEGINNING, endEvent));
 
         // Create a change set and return it.
         return new DbChangeSet(List.of(), creates);

--- a/examples/src/main/java/uk/gov/gchq/magmacore/examples/data/ExampleRdl.java
+++ b/examples/src/main/java/uk/gov/gchq/magmacore/examples/data/ExampleRdl.java
@@ -53,7 +53,7 @@ public class ExampleRdl {
         final IRI naturalMemberOfSocietyRole = new IRI(REF_BASE, uid());
         final IRI domesticPropertyRole = new IRI(REF_BASE, uid());
         final IRI domesticOccupantInPropertyRole = new IRI(REF_BASE, uid());
-        final IRI occupierOfPropertyRole = new IRI(REF_BASE, "occupierOfPropertyRole ");
+        final IRI occupierOfPropertyRole = new IRI(REF_BASE, "occupierOfPropertyRole");
         final IRI occupantInPropertyKindOfAssociation = new IRI(REF_BASE, uid());
 
         // Add DbCreateOperations to create the objects and their properties.

--- a/examples/src/main/java/uk/gov/gchq/magmacore/examples/data/ExampleRdl.java
+++ b/examples/src/main/java/uk/gov/gchq/magmacore/examples/data/ExampleRdl.java
@@ -58,122 +58,122 @@ public class ExampleRdl {
 
         // Add DbCreateOperations to create the objects and their properties.
         final List<DbCreateOperation> creates = List.of(
-                new DbCreateOperation(viewable, RDFS.RDF_TYPE, HQDM.CLASS.getIri()),
-                new DbCreateOperation(viewable, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(viewable, RDFS.RDF_TYPE, HQDM.CLASS),
+                new DbCreateOperation(viewable, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(viewable, HQDM.ENTITY_NAME, "VIEWABLE"),
 
-                new DbCreateOperation(viewableObject, RDFS.RDF_TYPE, HQDM.CLASS.getIri()),
-                new DbCreateOperation(viewableObject, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(viewableObject, RDFS.RDF_TYPE, HQDM.CLASS),
+                new DbCreateOperation(viewableObject, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(viewableObject, HQDM.ENTITY_NAME, "VIEWABLE_OBJECT"),
 
-                new DbCreateOperation(viewableAssociation, RDFS.RDF_TYPE, HQDM.CLASS.getIri()),
-                new DbCreateOperation(viewableAssociation, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(viewableAssociation, RDFS.RDF_TYPE, HQDM.CLASS),
+                new DbCreateOperation(viewableAssociation, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(viewableAssociation, HQDM.ENTITY_NAME, "VIEWABLE_ASSOCIATION"),
 
                 new DbCreateOperation(kindOfBiologicalSystemHumanComponent, RDFS.RDF_TYPE,
-                        HQDM.KIND_OF_BIOLOGICAL_SYSTEM_COMPONENT.getIri()),
-                new DbCreateOperation(kindOfBiologicalSystemHumanComponent, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                        HQDM.KIND_OF_BIOLOGICAL_SYSTEM_COMPONENT),
+                new DbCreateOperation(kindOfBiologicalSystemHumanComponent, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(kindOfBiologicalSystemHumanComponent, HQDM.ENTITY_NAME,
                         "KIND_OF_BIOLOGICAL_SYSTEM_HUMAN_COMPONENT"),
 
-                new DbCreateOperation(kindOfPerson, RDFS.RDF_TYPE, HQDM.KIND_OF_PERSON.getIri()),
-                new DbCreateOperation(kindOfPerson, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(kindOfPerson, RDFS.RDF_TYPE, HQDM.KIND_OF_PERSON),
+                new DbCreateOperation(kindOfPerson, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(kindOfPerson, HQDM.ENTITY_NAME, "KIND_OF_PERSON"),
 
-                new DbCreateOperation(classOfStateOfPerson, RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_PERSON.getIri()),
-                new DbCreateOperation(classOfStateOfPerson, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(classOfStateOfPerson, RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_PERSON),
+                new DbCreateOperation(classOfStateOfPerson, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(classOfStateOfPerson, HQDM.ENTITY_NAME, "CLASS_OF_STATE_OF_PERSON"),
 
                 new DbCreateOperation(kindOfFunctionalSystemBuilding, RDFS.RDF_TYPE,
-                        HQDM.KIND_OF_FUNCTIONAL_SYSTEM.getIri()),
-                new DbCreateOperation(kindOfFunctionalSystemBuilding, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                        HQDM.KIND_OF_FUNCTIONAL_SYSTEM),
+                new DbCreateOperation(kindOfFunctionalSystemBuilding, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(kindOfFunctionalSystemBuilding, HQDM.ENTITY_NAME,
                         "KIND_OF_FUNCTIONAL_SYSTEM_BUILDING"),
 
                 new DbCreateOperation(kindOfFunctionalSystemDomesticPropertyComponent, RDFS.RDF_TYPE,
-                        HQDM.KIND_OF_FUNCTIONAL_SYSTEM_COMPONENT.getIri()),
+                        HQDM.KIND_OF_FUNCTIONAL_SYSTEM_COMPONENT),
                 new DbCreateOperation(kindOfFunctionalSystemDomesticPropertyComponent, RDFS.RDF_TYPE,
-                        RDFS.RDFS_CLASS.getIri()),
+                        RDFS.RDFS_CLASS),
                 new DbCreateOperation(kindOfFunctionalSystemDomesticPropertyComponent, HQDM.ENTITY_NAME,
                         "KIND_OF_FUNCTIONAL_SYSTEM_DOMESTIC_PROPERTY_COMPONENT"),
 
                 new DbCreateOperation(kindOfFunctionalSystemDomesticProperty, RDFS.RDF_TYPE,
-                        HQDM.KIND_OF_FUNCTIONAL_SYSTEM.getIri()),
-                new DbCreateOperation(kindOfFunctionalSystemDomesticProperty, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                        HQDM.KIND_OF_FUNCTIONAL_SYSTEM),
+                new DbCreateOperation(kindOfFunctionalSystemDomesticProperty, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(kindOfFunctionalSystemDomesticProperty, HQDM.ENTITY_NAME,
                         "KIND_OF_FUNCTIONAL_SYSTEM_DOMESTIC_PROPERTY"),
 
                 new DbCreateOperation(classOfStateOfFunctionalSystemDomesticProperty, RDFS.RDF_TYPE,
-                        HQDM.CLASS_OF_STATE_OF_FUNCTIONAL_SYSTEM.getIri()),
+                        HQDM.CLASS_OF_STATE_OF_FUNCTIONAL_SYSTEM),
                 new DbCreateOperation(classOfStateOfFunctionalSystemDomesticProperty, RDFS.RDF_TYPE,
-                        RDFS.RDFS_CLASS.getIri()),
+                        RDFS.RDFS_CLASS),
                 new DbCreateOperation(classOfStateOfFunctionalSystemDomesticProperty, HQDM.ENTITY_NAME,
                         "STATE_OF_FUNCTIONAL_SYSTEM_DOMESTIC_PROPERTY"),
 
-                new DbCreateOperation(naturalMemberOfSocietyRole, RDFS.RDF_TYPE, HQDM.ROLE.getIri()),
-                new DbCreateOperation(naturalMemberOfSocietyRole, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(naturalMemberOfSocietyRole, RDFS.RDF_TYPE, HQDM.ROLE),
+                new DbCreateOperation(naturalMemberOfSocietyRole, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(naturalMemberOfSocietyRole, HQDM.ENTITY_NAME, "NATURAL_MEMBER_OF_SOCIETY_ROLE"),
 
-                new DbCreateOperation(domesticPropertyRole, RDFS.RDF_TYPE, HQDM.ROLE.getIri()),
-                new DbCreateOperation(domesticPropertyRole, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(domesticPropertyRole, RDFS.RDF_TYPE, HQDM.ROLE),
+                new DbCreateOperation(domesticPropertyRole, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(domesticPropertyRole, HQDM.ENTITY_NAME,
                         "ACCEPTED_PLACE_OF_SEMI_PERMANENT_HABITATION_ROLE"),
 
-                new DbCreateOperation(domesticOccupantInPropertyRole, RDFS.RDF_TYPE, HQDM.ROLE.getIri()),
-                new DbCreateOperation(domesticOccupantInPropertyRole, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(domesticOccupantInPropertyRole, RDFS.RDF_TYPE, HQDM.ROLE),
+                new DbCreateOperation(domesticOccupantInPropertyRole, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(domesticOccupantInPropertyRole, HQDM.ENTITY_NAME,
                         "DOMESTIC_PROPERTY_THAT_IS_OCCUPIED_ROLE"),
 
-                new DbCreateOperation(occupierOfPropertyRole, RDFS.RDF_TYPE, HQDM.ROLE.getIri()),
-                new DbCreateOperation(occupierOfPropertyRole, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                new DbCreateOperation(occupierOfPropertyRole, RDFS.RDF_TYPE, HQDM.ROLE),
+                new DbCreateOperation(occupierOfPropertyRole, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(occupierOfPropertyRole, HQDM.ENTITY_NAME, "OCCUPIER_LOCATED_IN_PROPERTY_ROLE"),
 
                 new DbCreateOperation(occupantInPropertyKindOfAssociation, RDFS.RDF_TYPE,
-                        HQDM.KIND_OF_ASSOCIATION.getIri()),
-                new DbCreateOperation(occupantInPropertyKindOfAssociation, RDFS.RDF_TYPE, RDFS.RDFS_CLASS.getIri()),
+                        HQDM.KIND_OF_ASSOCIATION),
+                new DbCreateOperation(occupantInPropertyKindOfAssociation, RDFS.RDF_TYPE, RDFS.RDFS_CLASS),
                 new DbCreateOperation(occupantInPropertyKindOfAssociation, HQDM.ENTITY_NAME,
                         "OCCUPANT_LOCATED_IN_VOLUME_ENCLOSED_BY_PROPERTY_ASSOCIATION"),
 
                 // Create the class hierarchy.
-                new DbCreateOperation(viewableObject, HQDM.HAS_SUPERCLASS, viewable.getIri()),
-                new DbCreateOperation(viewableObject, RDFS.RDFS_SUB_CLASS_OF, viewable.getIri()),
+                new DbCreateOperation(viewableObject, HQDM.HAS_SUPERCLASS, viewable),
+                new DbCreateOperation(viewableObject, RDFS.RDFS_SUB_CLASS_OF, viewable),
 
-                new DbCreateOperation(viewableAssociation, HQDM.HAS_SUPERCLASS, viewable.getIri()),
-                new DbCreateOperation(viewableAssociation, RDFS.RDFS_SUB_CLASS_OF, viewable.getIri()),
+                new DbCreateOperation(viewableAssociation, HQDM.HAS_SUPERCLASS, viewable),
+                new DbCreateOperation(viewableAssociation, RDFS.RDFS_SUB_CLASS_OF, viewable),
 
                 new DbCreateOperation(kindOfFunctionalSystemDomesticProperty, HQDM.HAS_SUPERCLASS,
-                        kindOfFunctionalSystemBuilding.getIri()),
+                        kindOfFunctionalSystemBuilding),
                 new DbCreateOperation(kindOfFunctionalSystemDomesticProperty, RDFS.RDFS_SUB_CLASS_OF,
-                        kindOfFunctionalSystemBuilding.getIri()),
+                        kindOfFunctionalSystemBuilding),
 
                 new DbCreateOperation(domesticOccupantInPropertyRole, HQDM.HAS_SUPERCLASS,
-                        domesticPropertyRole.getIri()),
+                        domesticPropertyRole),
                 new DbCreateOperation(domesticOccupantInPropertyRole, RDFS.RDFS_SUB_CLASS_OF,
-                        domesticPropertyRole.getIri()),
+                        domesticPropertyRole),
 
-                new DbCreateOperation(occupierOfPropertyRole, HQDM.HAS_SUPERCLASS, classOfStateOfPerson.getIri()),
-                new DbCreateOperation(occupierOfPropertyRole, RDFS.RDFS_SUB_CLASS_OF, classOfStateOfPerson.getIri()),
+                new DbCreateOperation(occupierOfPropertyRole, HQDM.HAS_SUPERCLASS, classOfStateOfPerson),
+                new DbCreateOperation(occupierOfPropertyRole, RDFS.RDFS_SUB_CLASS_OF, classOfStateOfPerson),
 
                 // Set class memberships.
-                new DbCreateOperation(kindOfPerson, HQDM.MEMBER_OF, viewableObject.getIri()),
-                new DbCreateOperation(classOfStateOfPerson, HQDM.MEMBER_OF, viewableObject.getIri()),
-                new DbCreateOperation(kindOfFunctionalSystemDomesticProperty, HQDM.MEMBER_OF, viewableObject.getIri()),
+                new DbCreateOperation(kindOfPerson, HQDM.MEMBER_OF, viewableObject),
+                new DbCreateOperation(classOfStateOfPerson, HQDM.MEMBER_OF, viewableObject),
+                new DbCreateOperation(kindOfFunctionalSystemDomesticProperty, HQDM.MEMBER_OF, viewableObject),
                 new DbCreateOperation(classOfStateOfFunctionalSystemDomesticProperty, HQDM.MEMBER_OF,
-                        viewableObject.getIri()),
+                        viewableObject),
                 new DbCreateOperation(occupantInPropertyKindOfAssociation, HQDM.MEMBER_OF,
-                        viewableAssociation.getIri()),
+                        viewableAssociation),
 
                 // Set the has component by class predicates.
                 new DbCreateOperation(kindOfBiologicalSystemHumanComponent, HQDM.HAS_COMPONENT_BY_CLASS,
-                        kindOfPerson.getIri()),
+                        kindOfPerson),
                 new DbCreateOperation(kindOfFunctionalSystemDomesticPropertyComponent, HQDM.HAS_COMPONENT_BY_CLASS,
-                        kindOfFunctionalSystemDomesticProperty.getIri()),
+                        kindOfFunctionalSystemDomesticProperty),
 
                 // Set the consists of by class predicates.
                 new DbCreateOperation(domesticOccupantInPropertyRole, HQDM.CONSISTS_OF_BY_CLASS,
-                        occupantInPropertyKindOfAssociation.getIri()),
+                        occupantInPropertyKindOfAssociation),
                 new DbCreateOperation(occupierOfPropertyRole, HQDM.CONSISTS_OF_BY_CLASS,
-                        occupantInPropertyKindOfAssociation.getIri()));
+                        occupantInPropertyKindOfAssociation));
 
         // Put the operations in a change set and return it.
         return new DbChangeSet(List.of(), creates);

--- a/examples/src/main/java/uk/gov/gchq/magmacore/examples/service/McAssistMultInheritFromDataApp.java
+++ b/examples/src/main/java/uk/gov/gchq/magmacore/examples/service/McAssistMultInheritFromDataApp.java
@@ -23,6 +23,7 @@ import uk.gov.gchq.magmacore.hqdm.model.StateOfOrganization;
 import uk.gov.gchq.magmacore.hqdm.model.Thing;
 import uk.gov.gchq.magmacore.hqdm.rdf.HqdmObjectFactory;
 import uk.gov.gchq.magmacore.hqdm.rdf.iri.HQDM;
+import uk.gov.gchq.magmacore.hqdm.rdf.iri.IRI;
 import uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS;
 import uk.gov.gchq.magmacore.hqdm.rdf.util.Pair;
 import uk.gov.gchq.magmacore.hqdm.rdf.util.Triples;
@@ -40,12 +41,12 @@ public class McAssistMultInheritFromDataApp {
     public static void main(final String[] args) {
 
         // Create a new type specification.
-        final List<Pair<String, String>> newTypeSpecification = List.of(
-                new Pair<>(RDFS.RDF_TYPE.getIri(), HQDM.STATE_OF_ORGANIZATION.getIri()),
-                new Pair<>(RDFS.RDF_TYPE.getIri(), HQDM.PARTICIPANT.getIri()));
+        final List<Pair<Object, Object>> newTypeSpecification = List.of(
+                new Pair<>(RDFS.RDF_TYPE, HQDM.STATE_OF_ORGANIZATION),
+                new Pair<>(RDFS.RDF_TYPE, HQDM.PARTICIPANT));
 
         // Create a new object using the type specification.
-        final Thing orgState = HqdmObjectFactory.create(uid(), newTypeSpecification);
+        final Thing orgState = HqdmObjectFactory.create(new IRI(uid()), newTypeSpecification);
 
         // Check that it implements the two interfaces.
         if (orgState instanceof Participant && orgState instanceof StateOfOrganization) {

--- a/examples/src/main/java/uk/gov/gchq/magmacore/examples/signs/ExampleSigns.java
+++ b/examples/src/main/java/uk/gov/gchq/magmacore/examples/signs/ExampleSigns.java
@@ -97,65 +97,65 @@ public class ExampleSigns {
         final List<DbCreateOperation> creates = List.of(
 
                 // Create the possible world that we are working in.
-                new DbCreateOperation(possibleWorld, RDFS.RDF_TYPE, HQDM.POSSIBLE_WORLD.getIri()),
+                new DbCreateOperation(possibleWorld, RDFS.RDF_TYPE, HQDM.POSSIBLE_WORLD),
                 new DbCreateOperation(possibleWorld, HQDM.ENTITY_NAME, "Example Signs World"),
 
                 // Create the thing represented.
-                new DbCreateOperation(person, RDFS.RDF_TYPE, HQDM.PERSON.getIri()),
-                new DbCreateOperation(person, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(person, RDFS.RDF_TYPE, HQDM.PERSON),
+                new DbCreateOperation(person, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
 
                 // Create the signs that represent the thing.
-                new DbCreateOperation(wikipediaSign, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN.getIri()),
-                new DbCreateOperation(wikipediaSign, HQDM.MEMBER_OF_, urlPattern.getId()),
+                new DbCreateOperation(wikipediaSign, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN),
+                new DbCreateOperation(wikipediaSign, HQDM.MEMBER_OF_, new IRI(urlPattern.getId())),
                 new DbCreateOperation(wikipediaSign, HQDM.VALUE_, "https://en.wikipedia.org/wiki/Socrates"),
-                new DbCreateOperation(wikipediaSign, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(wikipediaSign, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
 
-                new DbCreateOperation(britannica, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN.getIri()),
-                new DbCreateOperation(britannica, HQDM.MEMBER_OF_, urlPattern.getId()),
+                new DbCreateOperation(britannica, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN),
+                new DbCreateOperation(britannica, HQDM.MEMBER_OF_, new IRI(urlPattern.getId())),
                 new DbCreateOperation(britannica, HQDM.VALUE_, "https://www.britannica.com/biography/Socrates"),
-                new DbCreateOperation(britannica, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(britannica, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
 
-                new DbCreateOperation(biography, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN.getIri()),
-                new DbCreateOperation(biography, HQDM.MEMBER_OF_, urlPattern.getId()),
+                new DbCreateOperation(biography, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN),
+                new DbCreateOperation(biography, HQDM.MEMBER_OF_, new IRI(urlPattern.getId())),
                 new DbCreateOperation(biography, HQDM.VALUE_, "https://www.biography.com/scholar/socrates"),
-                new DbCreateOperation(biography, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(biography, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
 
-                new DbCreateOperation(stanford, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN.getIri()),
-                new DbCreateOperation(stanford, HQDM.MEMBER_OF_, urlPattern.getId()),
+                new DbCreateOperation(stanford, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN),
+                new DbCreateOperation(stanford, HQDM.MEMBER_OF_, new IRI(urlPattern.getId())),
                 new DbCreateOperation(stanford, HQDM.VALUE_, "https://plato.stanford.edu/entries/socrates/"),
-                new DbCreateOperation(stanford, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(stanford, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
 
-                new DbCreateOperation(nationalGeographic, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN.getIri()),
-                new DbCreateOperation(nationalGeographic, HQDM.MEMBER_OF_, urlPattern.getId()),
+                new DbCreateOperation(nationalGeographic, RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN),
+                new DbCreateOperation(nationalGeographic, HQDM.MEMBER_OF_, new IRI(urlPattern.getId())),
                 new DbCreateOperation(nationalGeographic, HQDM.VALUE_,
                         "https://www.nationalgeographic.com/culture/article/socrates"),
-                new DbCreateOperation(nationalGeographic, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(nationalGeographic, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
 
                 // Create the representation by signs.
-                new DbCreateOperation(representationBySign, RDFS.RDF_TYPE, HQDM.REPRESENTATION_BY_SIGN.getIri()),
-                new DbCreateOperation(representationBySign, HQDM.MEMBER_OF_, descriptionByUrl.getId()),
-                new DbCreateOperation(representationBySign, HQDM.REPRESENTS, person.getIri()),
-                new DbCreateOperation(representationBySign, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(representationBySign, RDFS.RDF_TYPE, HQDM.REPRESENTATION_BY_SIGN),
+                new DbCreateOperation(representationBySign, HQDM.MEMBER_OF_, new IRI(descriptionByUrl.getId())),
+                new DbCreateOperation(representationBySign, HQDM.REPRESENTS, person),
+                new DbCreateOperation(representationBySign, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
 
                 // Add beginning, ending, etc. from `association`.
-                new DbCreateOperation(startEvent, RDFS.RDF_TYPE, HQDM.EVENT.getIri()),
-                new DbCreateOperation(startEvent, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(startEvent, RDFS.RDF_TYPE, HQDM.EVENT),
+                new DbCreateOperation(startEvent, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
                 new DbCreateOperation(startEvent, HQDM.ENTITY_NAME, "2020-01-01T00:00:00"),
 
-                new DbCreateOperation(endEvent, RDFS.RDF_TYPE, HQDM.EVENT.getIri()),
-                new DbCreateOperation(endEvent, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld.getIri()),
+                new DbCreateOperation(endEvent, RDFS.RDF_TYPE, HQDM.EVENT),
+                new DbCreateOperation(endEvent, HQDM.PART_OF_POSSIBLE_WORLD, possibleWorld),
                 new DbCreateOperation(endEvent, HQDM.ENTITY_NAME, "2022-12-01T00:00:00"),
 
-                new DbCreateOperation(representationBySign, HQDM.BEGINNING, startEvent.getIri()),
-                new DbCreateOperation(representationBySign, HQDM.ENDING, endEvent.getIri()),
+                new DbCreateOperation(representationBySign, HQDM.BEGINNING, startEvent),
+                new DbCreateOperation(representationBySign, HQDM.ENDING, endEvent),
 
                 // Add the participants.
-                new DbCreateOperation(englishSpeakersIri, HQDM.PARTICIPANT_IN, representationBySign.getIri()),
-                new DbCreateOperation(wikipediaSign, HQDM.PARTICIPANT_IN, representationBySign.getIri()),
-                new DbCreateOperation(britannica, HQDM.PARTICIPANT_IN, representationBySign.getIri()),
-                new DbCreateOperation(biography, HQDM.PARTICIPANT_IN, representationBySign.getIri()),
-                new DbCreateOperation(stanford, HQDM.PARTICIPANT_IN, representationBySign.getIri()),
-                new DbCreateOperation(nationalGeographic, HQDM.PARTICIPANT_IN, representationBySign.getIri()));
+                new DbCreateOperation(englishSpeakersIri, HQDM.PARTICIPANT_IN, representationBySign),
+                new DbCreateOperation(wikipediaSign, HQDM.PARTICIPANT_IN, representationBySign),
+                new DbCreateOperation(britannica, HQDM.PARTICIPANT_IN, representationBySign),
+                new DbCreateOperation(biography, HQDM.PARTICIPANT_IN, representationBySign),
+                new DbCreateOperation(stanford, HQDM.PARTICIPANT_IN, representationBySign),
+                new DbCreateOperation(nationalGeographic, HQDM.PARTICIPANT_IN, representationBySign));
 
         // Create a change set and return it.
         return new DbChangeSet(List.of(), creates);

--- a/examples/src/main/java/uk/gov/gchq/magmacore/examples/signs/ExampleSignsRdl.java
+++ b/examples/src/main/java/uk/gov/gchq/magmacore/examples/signs/ExampleSignsRdl.java
@@ -45,18 +45,18 @@ public class ExampleSignsRdl {
 
         // Add DbCreateOperations to create the objects and their properties.
         final List<DbCreateOperation> creates = List.of(
-                new DbCreateOperation(urlPattern, RDFS.RDF_TYPE, HQDM.PATTERN.getIri()),
+                new DbCreateOperation(urlPattern, RDFS.RDF_TYPE, HQDM.PATTERN),
                 new DbCreateOperation(urlPattern, HQDM.ENTITY_NAME, "URL Pattern"),
 
-                new DbCreateOperation(description, RDFS.RDF_TYPE, HQDM.DESCRIPTION.getIri()),
+                new DbCreateOperation(description, RDFS.RDF_TYPE, HQDM.DESCRIPTION),
                 new DbCreateOperation(description, HQDM.ENTITY_NAME, "Description By URL"),
 
                 // Create the community that recognizes the signs.
-                new DbCreateOperation(englishSpeakers, RDFS.RDF_TYPE, HQDM.RECOGNIZING_LANGUAGE_COMMUNITY.getIri()),
+                new DbCreateOperation(englishSpeakers, RDFS.RDF_TYPE, HQDM.RECOGNIZING_LANGUAGE_COMMUNITY),
                 new DbCreateOperation(englishSpeakers, HQDM.ENTITY_NAME, "English Speakers"),
 
                 // Link the description to the Pattern.
-                new DbCreateOperation(description, HQDM.CONSISTS_OF_BY_CLASS, urlPattern.getIri())
+                new DbCreateOperation(description, HQDM.CONSISTS_OF_BY_CLASS, urlPattern)
 
         );
 

--- a/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/HqdmObjectFactory.java
+++ b/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/HqdmObjectFactory.java
@@ -63,30 +63,30 @@ public final class HqdmObjectFactory {
      * @return The constructed HQDM object.
      * @throws HqdmException If the HqdmObject could not be built.
      */
-    public static Thing create(final String iri, final List<Pair<String, String>> pairs) throws HqdmException {
+    public static Thing create(final IRI iri, final List<Pair<Object, Object>> pairs) throws HqdmException {
         try {
             final List<IRI> iris = new ArrayList<>();
-            for (final Pair<String, String> pair : pairs.stream()
-                    .filter(pair -> pair.getLeft().equals(RDF_TYPE.toString()))
-                    .filter(pair -> pair.getRight().startsWith(HQDM.HQDM.getNamespace()))
+            for (final Pair<Object, Object> pair : pairs.stream()
+                    .filter(pair -> pair.getLeft().equals(RDF_TYPE))
+                    .filter(pair -> pair.getRight().toString().startsWith(HQDM.HQDM.getNamespace()))
                     .collect(Collectors.toList())) {
-                iris.add(new IRI(pair.getRight()));
+                iris.add((IRI) pair.getRight());
             }
 
             if (!iris.isEmpty()) {
                 final Thing result;
 
                 if (iris.size() == 1) {
-                    result = mapToThing(iris.get(0).getResource(), new IRI(iri));
+                    result = mapToThing(iris.get(0).getResource(), iri);
                 } else {
-                    result = DynamicObjects.create(iri, Thing.class, irisToClasses(iris));
+                    result = DynamicObjects.create(iri.toString(), Thing.class, irisToClasses(iris));
                 }
 
-                for (final Pair<String, String> pair : pairs) {
-                    if (pair.getRight().startsWith("http")) {
+                for (final Pair<Object, Object> pair : pairs) {
+                    if (pair.getRight() instanceof IRI) {
                         result.addValue(pair.getLeft(), pair.getRight());
                     } else {
-                        result.addStringValue(pair.getLeft(), pair.getRight());
+                        result.addStringValue(pair.getLeft(), pair.getRight().toString());
                     }
                 }
                 return result;

--- a/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/iri/IRI.java
+++ b/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/iri/IRI.java
@@ -70,11 +70,13 @@ public class IRI {
     /**
      * Convert a {@link String} to an IRI.
      *
-     * @param iri {@link String}
+     * @param rawIri {@link String}
      * @throws IriException if the {@link String} is not a valid URL.
      */
-    private void fromString(final String iri) throws IriException {
+    private void fromString(final String rawIri) throws IriException {
+        final String iri = rawIri.trim();
         try {
+
             new URL(iri);
             this.iri = iri;
         } catch (final MalformedURLException m) {

--- a/hqdm-rdf/src/test/java/uk/gov/gchq/magmacore/hqdm/rdf/HqdmObjectFactoryTest.java
+++ b/hqdm-rdf/src/test/java/uk/gov/gchq/magmacore/hqdm/rdf/HqdmObjectFactoryTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import uk.gov.gchq.magmacore.hqdm.exception.HqdmException;
 import uk.gov.gchq.magmacore.hqdm.model.Participant;
 import uk.gov.gchq.magmacore.hqdm.model.Person;
-import uk.gov.gchq.magmacore.hqdm.rdf.HqdmObjectFactory;
 import uk.gov.gchq.magmacore.hqdm.rdf.iri.HQDM;
 import uk.gov.gchq.magmacore.hqdm.rdf.iri.HqdmIri;
 import uk.gov.gchq.magmacore.hqdm.rdf.iri.IRI;
@@ -48,11 +47,11 @@ public class HqdmObjectFactoryTest {
 
         // Create a new person with an ENTITY_NAME.
         final var person = HqdmObjectFactory.create(HQDM.PERSON, personIri);
-        person.addValue(HQDM.ENTITY_NAME.getIri(), personId);
+        person.addValue(HQDM.ENTITY_NAME, personId);
 
         // Assert the ENTITY_NAME and person IRI are as expected.
         assertNotNull(person);
-        assertEquals(Set.of(personId), person.value(HQDM.ENTITY_NAME.getIri()));
+        assertEquals(Set.of(personId), person.value(HQDM.ENTITY_NAME));
         assertEquals(personIri.getIri(), person.getId());
     }
 
@@ -76,15 +75,15 @@ public class HqdmObjectFactoryTest {
         final var personId = "person1";
         final var personIri = new IRI(HQDM.HQDM, personId);
 
-        final var person = HqdmObjectFactory.create(personIri.getIri(),
-                List.of(new Pair<>(RDFS.RDF_TYPE.getIri(), HQDM.PERSON.getIri()),
-                        new Pair<>(HQDM.ENTITY_NAME.getIri(), personId),
-                        new Pair<>(HQDM.MEMBER_OF_KIND.getIri(), "PERSON_KIND")));
+        final var person = HqdmObjectFactory.create(personIri,
+                List.of(new Pair<>(RDFS.RDF_TYPE, HQDM.PERSON),
+                        new Pair<>(HQDM.ENTITY_NAME, personId),
+                        new Pair<>(HQDM.MEMBER_OF_KIND, "PERSON_KIND")));
 
         // Assert the values are correct.
         assertNotNull(person);
-        assertEquals(Set.of(personId), person.value(HQDM.ENTITY_NAME.getIri()));
-        assertEquals(Set.of("PERSON_KIND"), person.value(HQDM.MEMBER_OF_KIND.getIri()));
+        assertEquals(Set.of(personId), person.value(HQDM.ENTITY_NAME));
+        assertEquals(Set.of("PERSON_KIND"), person.value(HQDM.MEMBER_OF_KIND));
         assertEquals(personIri.getIri(), person.getId());
     }
 
@@ -97,16 +96,16 @@ public class HqdmObjectFactoryTest {
         final var personId = "person1";
         final var personIri = new IRI(HQDM.HQDM, personId);
 
-        final var person = HqdmObjectFactory.create(personIri.getIri(),
-                List.of(new Pair<>(RDFS.RDF_TYPE.getIri(), HQDM.PERSON.getIri()),
-                        new Pair<>(RDFS.RDF_TYPE.getIri(), HQDM.PARTICIPANT.getIri()),
-                        new Pair<>(HQDM.ENTITY_NAME.getIri(), personId)));
+        final var person = HqdmObjectFactory.create(personIri,
+                List.of(new Pair<>(RDFS.RDF_TYPE, HQDM.PERSON),
+                        new Pair<>(RDFS.RDF_TYPE, HQDM.PARTICIPANT),
+                        new Pair<>(HQDM.ENTITY_NAME, personId)));
 
         // Assert the values are correct.
         assertNotNull(person);
         assertTrue(person instanceof Person);
         assertTrue(person instanceof Participant);
-        assertEquals(Set.of(personId), person.value(HQDM.ENTITY_NAME.getIri()));
+        assertEquals(Set.of(personId), person.value(HQDM.ENTITY_NAME));
         assertEquals(personIri.getIri(), person.getId());
     }
 }

--- a/hqdm-rdf/src/test/java/uk/gov/gchq/magmacore/hqdm/rdf/util/TriplesTest.java
+++ b/hqdm-rdf/src/test/java/uk/gov/gchq/magmacore/hqdm/rdf/util/TriplesTest.java
@@ -24,8 +24,6 @@ import uk.gov.gchq.magmacore.hqdm.rdf.HqdmObjectFactory;
 import uk.gov.gchq.magmacore.hqdm.rdf.iri.HQDM;
 import uk.gov.gchq.magmacore.hqdm.rdf.iri.IRI;
 import uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS;
-import uk.gov.gchq.magmacore.hqdm.rdf.util.Pair;
-import uk.gov.gchq.magmacore.hqdm.rdf.util.Triples;
 
 /**
  * Tests for the {@link Triples} class.
@@ -34,9 +32,9 @@ public class TriplesTest {
 
     private static final String EXPECTED1 = """
             <http://www.semanticweb.org/hqdm#person1> <http://www.semanticweb.org/hqdm#member_of_kind> \"\"\"PERSON_KIND\"\"\"^^<http://www.w3.org/2001/XMLSchema#string>;
-            <http://www.semanticweb.org/hqdm#data_EntityName> \"\"\"person1\"\"\"^^<http://www.w3.org/2001/XMLSchema#string>;
-            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \"\"\"http://www.semanticweb.org/hqdm#participant\"\"\"^^<http://www.w3.org/2001/XMLSchema#string>;
-            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \"\"\"http://www.semanticweb.org/hqdm#person\"\"\"^^<http://www.w3.org/2001/XMLSchema#string>.
+            <http://www.semanticweb.org/hqdm#data_EntityName> <http://www.semanticweb.org/hqdm#person1>;
+            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.semanticweb.org/hqdm#participant>;
+            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.semanticweb.org/hqdm#person>.
             """;
 
     /**
@@ -48,15 +46,15 @@ public class TriplesTest {
         final var personId = "person1";
         final var personIri = new IRI(HQDM.HQDM, personId);
 
-        final var person = HqdmObjectFactory.create(personIri.getIri(),
-                List.of(new Pair<>(RDFS.RDF_TYPE.getIri(), HQDM.PERSON.getIri()),
-                        new Pair<>(RDFS.RDF_TYPE.getIri(), HQDM.PARTICIPANT.getIri()),
-                        new Pair<>(HQDM.ENTITY_NAME.getIri(), personId),
-                        new Pair<>(HQDM.MEMBER_OF_KIND.getIri(), "PERSON_KIND")));
+        final var person = HqdmObjectFactory.create(personIri,
+                List.of(new Pair<>(RDFS.RDF_TYPE, HQDM.PERSON),
+                        new Pair<>(RDFS.RDF_TYPE, HQDM.PARTICIPANT),
+                        new Pair<>(HQDM.ENTITY_NAME, personIri),
+                        new Pair<>(HQDM.MEMBER_OF_KIND, "PERSON_KIND")));
 
         // Convert the object to a triples string.
         final var triples = Triples.toTriples(person);
-
+        System.out.println(triples);
         // Assert the values are correct.
         assertEquals(EXPECTED1, triples);
     }

--- a/hqdm/src/main/java/uk/gov/gchq/magmacore/hqdm/pojo/HqdmObject.java
+++ b/hqdm/src/main/java/uk/gov/gchq/magmacore/hqdm/pojo/HqdmObject.java
@@ -29,7 +29,7 @@ public abstract class HqdmObject implements Thing {
 
     private String id;
 
-    private final Map<String, Set<Object>> predicates = new HashMap<>();
+    private final Map<Object, Set<Object>> predicates = new HashMap<>();
 
     /**
      * Constructs a new {@code HqdmObject}.
@@ -57,25 +57,25 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public Map<String, Set<Object>> getPredicates() {
+    public Map<Object, Set<Object>> getPredicates() {
         return predicates;
     }
 
     /**
      * {@inheritDoc}
      */
-    public void setPredicates(final Map<String, Set<Object>> predicates) {
+    public void setPredicates(final Map<Object, Set<Object>> predicates) {
         // Convert some values to Strings if necessary - required when deserializing the
         // object.
         if (!predicates.isEmpty()) {
             this.predicates.clear();
-            for (final Map.Entry<String, Set<Object>> entry : predicates.entrySet()) {
+            for (final Map.Entry<Object, Set<Object>> entry : predicates.entrySet()) {
                 final Object value = entry.getValue().iterator().next();
-                final String key = entry.getKey();
+                final Object key = entry.getKey();
                 if (value instanceof Map) {
                     final Map valueMap = (Map) value;
                     this.predicates.remove(key);
-                    this.addValue(key, new String(valueMap.get("id").toString()));
+                    this.addValue(key, valueMap.get("id"));
                 } else {
                     this.predicates.put(key, entry.getValue());
                 }
@@ -86,14 +86,14 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public Set<Object> value(final String predicateId) {
+    public Set<Object> value(final Object predicateId) {
         return predicates.get(predicateId);
     }
 
     /**
      * {@inheritDoc}
      */
-    public void addValue(final String predicateId, final String objectId) {
+    public void addValue(final Object predicateId, final Object objectId) {
         final Set<Object> values = predicates.computeIfAbsent(predicateId, k -> new HashSet<>());
         values.add(objectId);
     }
@@ -101,7 +101,7 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public void addStringValue(final String predicateId, final String value) {
+    public void addStringValue(final Object predicateId, final String value) {
         final Set<Object> values = predicates.computeIfAbsent(predicateId, k -> new HashSet<>());
         values.add(value);
     }
@@ -109,7 +109,7 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public void addRealValue(final String predicateId, final double value) {
+    public void addRealValue(final Object predicateId, final double value) {
         final Set<Object> values = predicates.computeIfAbsent(predicateId, k -> new HashSet<>());
         values.add(value);
     }
@@ -117,7 +117,7 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public void removeValue(final String predicateId, final String value) {
+    public void removeValue(final Object predicateId, final Object value) {
         if (predicates.containsKey(predicateId)) {
             final var v = predicates.get(predicateId);
             if (v.contains(value)) {
@@ -129,14 +129,14 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public boolean hasValue(final String predicateId) {
+    public boolean hasValue(final Object predicateId) {
         return predicates.containsKey(predicateId);
     }
 
     /**
      * {@inheritDoc}
      */
-    public boolean hasThisValue(final String predicateId, final String objectId) {
+    public boolean hasThisValue(final Object predicateId, final Object objectId) {
         final Set<Object> values = predicates.get(predicateId);
         return values != null && values.contains(objectId);
     }
@@ -144,7 +144,7 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public boolean hasThisStringValue(final String predicateId, final String value) {
+    public boolean hasThisStringValue(final Object predicateId, final String value) {
         final Set<Object> values = predicates.get(predicateId);
         return values != null && values.contains(value);
     }
@@ -152,7 +152,7 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public boolean hasThisStringValueIgnoreCase(final String predicateId, final String value) {
+    public boolean hasThisStringValueIgnoreCase(final Object predicateId, final String value) {
         final Set<Object> values = predicates.get(predicateId);
         if (values != null) {
             for (final Object object : values) {
@@ -167,7 +167,7 @@ public abstract class HqdmObject implements Thing {
     /**
      * {@inheritDoc}
      */
-    public boolean hasThisStringValueFuzzy(final String predicateId, final String value) {
+    public boolean hasThisStringValueFuzzy(final Object predicateId, final String value) {
         final Set<Object> values = predicates.get(predicateId);
         if (values != null) {
             for (final Object object : values) {

--- a/hqdm/src/main/java/uk/gov/gchq/magmacore/hqdm/pojo/Top.java
+++ b/hqdm/src/main/java/uk/gov/gchq/magmacore/hqdm/pojo/Top.java
@@ -39,24 +39,24 @@ public interface Top {
     /**
      * Get the predications of the HQDM object.
      *
-     * @return Map of HQDM objects and String predicates of the entity.
+     * @return Map of HQDM objects and Object predicates of the entity.
      */
-    Map<String, Set<Object>> getPredicates();
+    Map<Object, Set<Object>> getPredicates();
 
     /**
      * Set the predications of the HQDM object.
      *
      * @param predicates Predicates of the HQDM object.
      */
-    void setPredicates(Map<String, Set<Object>> predicates);
+    void setPredicates(Map<Object, Set<Object>> predicates);
 
     /**
-     * Get predicate value(s) by predicate String.
+     * Get predicate value(s) by predicate Object.
      *
      * @param predicateId Predicate ID.
-     * @return Set of predicate values (Strings or string-literals).
+     * @return Set of predicate values (Object or string-literals).
      */
-    Set<Object> value(String predicateId);
+    Set<Object> value(Object predicateId);
 
     /**
      * Add predicate and object String reference to entity.
@@ -64,31 +64,31 @@ public interface Top {
      * @param predicateId Predicate ID.
      * @param objectId    ID of the object.
      */
-    void addValue(String predicateId, String objectId);
+    void addValue(Object predicateId, Object objectId);
 
     /**
-     * Add predicate String and string value to object.
+     * Add predicate Object and string value to object.
      *
      * @param predicateId Predicate ID.
      * @param value       String value.
      */
-    void addStringValue(String predicateId, String value);
+    void addStringValue(Object predicateId, String value);
 
     /**
-     * Add predicate String and real number value to object.
+     * Add predicate Object and real number value to object.
      *
      * @param predicateId Predicate ID.
      * @param value       Real number value.
      */
-    void addRealValue(String predicateId, double value);
+    void addRealValue(Object predicateId, double value);
 
     /**
      * Remove a predicate value.
      *
      * @param predicateId The ID of the predicate.
-     * @param value       The {@link String} value to be removed.
+     * @param value       The {@link Object} value to be removed.
      */
-    void removeValue(String predicateId, String value);
+    void removeValue(Object predicateId, Object value);
 
     /**
      * Does the entity have a given predicate.
@@ -96,7 +96,7 @@ public interface Top {
      * @param predicateId Predicate ID.
      * @return {@code true} if has predicate value.
      */
-    boolean hasValue(String predicateId);
+    boolean hasValue(Object predicateId);
 
     /**
      * Does the entity have a given predicate and object value.
@@ -105,7 +105,7 @@ public interface Top {
      * @param objectId    ID of the object.
      * @return {@code true} if has this object value.
      */
-    boolean hasThisValue(String predicateId, String objectId);
+    boolean hasThisValue(Object predicateId, Object objectId);
 
     /**
      * Does the entity have a given predicate and string value.
@@ -114,7 +114,7 @@ public interface Top {
      * @param value       String value.
      * @return {@code true} if has this string value.
      */
-    boolean hasThisStringValue(String predicateId, String value);
+    boolean hasThisStringValue(Object predicateId, String value);
 
     /**
      * Does the entity have a given predicate and string value (case-insensitive).
@@ -123,7 +123,7 @@ public interface Top {
      * @param value       Case-insensitive string value.
      * @return {@code true} if has this string value.
      */
-    boolean hasThisStringValueIgnoreCase(String predicateId, String value);
+    boolean hasThisStringValueIgnoreCase(Object predicateId, String value);
 
     /**
      * Does the entity have a given predicate and string value.
@@ -132,5 +132,5 @@ public interface Top {
      * @param value       String value.
      * @return {@code true} if has fuzzy string value.
      */
-    boolean hasThisStringValueFuzzy(String predicateId, String value);
+    boolean hasThisStringValueFuzzy(Object predicateId, String value);
 }


### PR DESCRIPTION
- Allow `predicate` and `object` values to be Java Object values in the `hqdm` module. This is to allow `IRI` objects to be used without `iri.getIri()` having to be used everywhere.
- Update the `Remote` and `Jena` databases to create `Resource` objects for `IRI` objects rather than using `Strings`. This allows us to distinguish between `IRIs` that are resource identifiers and `URIs` that we want to store as `String` values.
- Follow through the above changes to the affected code, examples, and unit tests.