### PR TITLE
Add Rdf*Service classes to enforce rdf:type predicates

### DIFF
--- a/hqdm-rdf/src/main/java/module-info.java
+++ b/hqdm-rdf/src/main/java/module-info.java
@@ -22,4 +22,5 @@ module uk.gov.gchq.magmacore.hqdm.rdf {
     exports uk.gov.gchq.magmacore.hqdm.rdf.iri;
     exports uk.gov.gchq.magmacore.hqdm.rdf.util;
     exports uk.gov.gchq.magmacore.hqdm.rdf;
+    exports uk.gov.gchq.magmacore.hqdm.rdfservices;
 }

--- a/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfClassServices.java
+++ b/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfClassServices.java
@@ -969,6 +969,18 @@ public class RdfClassServices {
     }
 
     /**
+     * Create a {@link EnumeratedClass} with an String.
+     *
+     * @param id ID of the EnumeratedClass.
+     * @return A EnumeratedClass instance.
+     */
+    public static EnumeratedClass createEnumeratedClass(final String id) {
+        final EnumeratedClass result = ClassServices.createEnumeratedClass(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ENUMERATED_CLASS);
+        return result;
+    }
+
+    /**
      * Create a {@link KindOfActivity} with an String.
      *
      * @param id ID of the KindOfActivity.

--- a/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfClassServices.java
+++ b/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfClassServices.java
@@ -1,0 +1,1296 @@
+/*
+ * Copyright 2021 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package uk.gov.gchq.magmacore.hqdm.rdfservices;
+
+import uk.gov.gchq.magmacore.hqdm.model.*;
+import uk.gov.gchq.magmacore.hqdm.model.Class;
+import uk.gov.gchq.magmacore.hqdm.rdf.iri.HQDM;
+import uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS;
+import uk.gov.gchq.magmacore.hqdm.services.ClassServices;
+
+/**
+ * Service for creating HQDM Classes.
+ */
+public class RdfClassServices {
+    /**
+     * Create a {@link Class} with an String.
+     *
+     * @param id ID of the Class.
+     * @return A Class instance.
+     */
+    public static Class createClass(final String id) {
+        final Class result = ClassServices.createClass(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfAbstractObject} with an String.
+     *
+     * @param id ID of the ClassOfAbstractObject.
+     * @return A ClassOfAbstractObject instance.
+     */
+    public static ClassOfAbstractObject createClassOfAbstractObject(final String id) {
+        final ClassOfAbstractObject result = ClassServices.createClassOfAbstractObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_ABSTRACT_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfActivity} with an String.
+     *
+     * @param id ID of the ClassOfActivity.
+     * @return A ClassOfActivity instance.
+     */
+    public static ClassOfActivity createClassOfActivity(final String id) {
+        final ClassOfActivity result = ClassServices.createClassOfActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfAgreeContract} with an String.
+     *
+     * @param id ID of the ClassOfAgreeContract.
+     * @return A ClassOfAgreeContract instance.
+     */
+    public static ClassOfAgreeContract createClassOfAgreeContract(final String id) {
+        final ClassOfAgreeContract result = ClassServices.createClassOfAgreeContract(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_AGREE_CONTRACT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfAgreementExecution} with an String.
+     *
+     * @param id ID of the ClassOfAgreementExecution.
+     * @return A ClassOfAgreementExecution instance.
+     */
+    public static ClassOfAgreementExecution createClassOfAgreementExecution(final String id) {
+        final ClassOfAgreementExecution result = ClassServices.createClassOfAgreementExecution(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_AGREEMENT_EXECUTION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfAgreementProcess} with an String.
+     *
+     * @param id ID of the ClassOfAgreementProcess.
+     * @return A ClassOfAgreementProcess instance.
+     */
+    public static ClassOfAgreementProcess createClassOfAgreementProcess(final String id) {
+        final ClassOfAgreementProcess result = ClassServices.createClassOfAgreementProcess(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_AGREEMENT_PROCESS);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfAmountOfMoney} with an String.
+     *
+     * @param id ID of the ClassOfAmountOfMoney.
+     * @return A ClassOfAmountOfMoney instance.
+     */
+    public static ClassOfAmountOfMoney createClassOfAmountOfMoney(final String id) {
+        final ClassOfAmountOfMoney result = ClassServices.createClassOfAmountOfMoney(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_AMOUNT_OF_MONEY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfAssociation} with an String.
+     *
+     * @param id ID of the ClassOfAssociation.
+     * @return A ClassOfAssociation instance.
+     */
+    public static ClassOfAssociation createClassOfAssociation(final String id) {
+        final ClassOfAssociation result = ClassServices.createClassOfAssociation(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_ASSOCIATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfBiologicalObject} with an String.
+     *
+     * @param id ID of the ClassOfBiologicalObject.
+     * @return A ClassOfBiologicalObject instance.
+     */
+    public static ClassOfBiologicalObject createClassOfBiologicalObject(final String id) {
+        final ClassOfBiologicalObject result = ClassServices.createClassOfBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfBiologicalSystem} with an String.
+     *
+     * @param id ID of the ClassOfBiologicalSystem.
+     * @return A ClassOfBiologicalSystem instance.
+     */
+    public static ClassOfBiologicalSystem createClassOfBiologicalSystem(final String id) {
+        final ClassOfBiologicalSystem result = ClassServices.createClassOfBiologicalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_BIOLOGICAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfBiologicalSystemComponent} with an String.
+     *
+     * @param id ID of the ClassOfBiologicalSystemComponent.
+     * @return A ClassOfBiologicalSystemComponent instance.
+     */
+    public static ClassOfBiologicalSystemComponent createClassOfBiologicalSystemComponent(final String id) {
+        final ClassOfBiologicalSystemComponent result = ClassServices.createClassOfBiologicalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_BIOLOGICAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfClass} with an String.
+     *
+     * @param id ID of the ClassOfClass.
+     * @return A ClassOfClass instance.
+     */
+    public static ClassOfClass createClassOfClass(final String id) {
+        final ClassOfClass result = ClassServices.createClassOfClass(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_CLASS);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfClassOfSpatioTemporalExtent} with an String.
+     *
+     * @param id ID of the ClassOfClassOfSpatioTemporalExtent.
+     * @return A ClassOfClassOfSpatioTemporalExtent instance.
+     */
+    public static ClassOfClassOfSpatioTemporalExtent createClassOfClassOfSpatioTemporalExtent(final String id) {
+        final ClassOfClassOfSpatioTemporalExtent result = ClassServices.createClassOfClassOfSpatioTemporalExtent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_CLASS_OF_SPATIO_TEMPORAL_EXTENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfContractExecution} with an String.
+     *
+     * @param id ID of the ClassOfContractExecution.
+     * @return A ClassOfContractExecution instance.
+     */
+    public static ClassOfContractExecution createClassOfContractExecution(final String id) {
+        final ClassOfContractExecution result = ClassServices.createClassOfContractExecution(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_CONTRACT_EXECUTION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfContractProcess} with an String.
+     *
+     * @param id ID of the ClassOfContractProcess.
+     * @return A ClassOfContractProcess instance.
+     */
+    public static ClassOfContractProcess createClassOfContractProcess(final String id) {
+        final ClassOfContractProcess result = ClassServices.createClassOfContractProcess(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_CONTRACT_PROCESS);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfEvent} with an String.
+     *
+     * @param id ID of the ClassOfEvent.
+     * @return A ClassOfEvent instance.
+     */
+    public static ClassOfEvent createClassOfEvent(final String id) {
+        final ClassOfEvent result = ClassServices.createClassOfEvent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_EVENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfFunctionalObject} with an String.
+     *
+     * @param id ID of the ClassOfFunctionalObject.
+     * @return A ClassOfFunctionalObject instance.
+     */
+    public static ClassOfFunctionalObject createClassOfFunctionalObject(final String id) {
+        final ClassOfFunctionalObject result = ClassServices.createClassOfFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfFunctionalSystem} with an String.
+     *
+     * @param id ID of the ClassOfFunctionalSystem.
+     * @return A ClassOfFunctionalSystem instance.
+     */
+    public static ClassOfFunctionalSystem createClassOfFunctionalSystem(final String id) {
+        final ClassOfFunctionalSystem result = ClassServices.createClassOfFunctionalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_FUNCTIONAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfFunctionalSystemComponent} with an String.
+     *
+     * @param id ID of the ClassOfFunctionalSystemComponent.
+     * @return A ClassOfFunctionalSystemComponent instance.
+     */
+    public static ClassOfFunctionalSystemComponent createClassOfFunctionalSystemComponent(final String id) {
+        final ClassOfFunctionalSystemComponent result = ClassServices.createClassOfFunctionalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_FUNCTIONAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfInPlaceBiologicalComponent} with an String.
+     *
+     * @param id ID of the ClassOfInPlaceBiologicalComponent.
+     * @return A ClassOfInPlaceBiologicalComponent instance.
+     */
+    public static ClassOfInPlaceBiologicalComponent createClassOfInPlaceBiologicalComponent(final String id) {
+        final ClassOfInPlaceBiologicalComponent result = ClassServices.createClassOfInPlaceBiologicalComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_IN_PLACE_BIOLOGICAL_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfIndividual} with an String.
+     *
+     * @param id ID of the ClassOfIndividual.
+     * @return A ClassOfIndividual instance.
+     */
+    public static ClassOfIndividual createClassOfIndividual(final String id) {
+        final ClassOfIndividual result = ClassServices.createClassOfIndividual(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_INDIVIDUAL);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfInstalledFunctionalSystemComponent} with an String.
+     *
+     * @param id ID of the ClassOfInstalledFunctionalSystemComponent.
+     * @return A ClassOfInstalledFunctionalSystemComponent instance.
+     */
+    public static ClassOfInstalledFunctionalSystemComponent createClassOfInstalledFunctionalSystemComponent(
+            final String id) {
+        final ClassOfInstalledFunctionalSystemComponent result = ClassServices
+
+                .createClassOfInstalledFunctionalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_INSTALLED_FUNCTIONAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfInstalledObject} with an String.
+     *
+     * @param id ID of the ClassOfInstalledObject.
+     * @return A ClassOfInstalledObject instance.
+     */
+    public static ClassOfInstalledObject createClassOfInstalledObject(final String id) {
+        final ClassOfInstalledObject result = ClassServices.createClassOfInstalledObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_INSTALLED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfIntentionallyConstructedObject} with an String.
+     *
+     * @param id ID of the ClassOfIntentionallyConstructedObject.
+     * @return A ClassOfIntentionallyConstructedObject instance.
+     */
+    public static ClassOfIntentionallyConstructedObject createClassOfIntentionallyConstructedObject(final String id) {
+        final ClassOfIntentionallyConstructedObject result = ClassServices
+                .createClassOfIntentionallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_INTENTIONALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfOffer} with an String.
+     *
+     * @param id ID of the ClassOfOffer.
+     * @return A ClassOfOffer instance.
+     */
+    public static ClassOfOffer createClassOfOffer(final String id) {
+        final ClassOfOffer result = ClassServices.createClassOfOffer(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_OFFER);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfOrdinaryBiologicalObject} with an String.
+     *
+     * @param id ID of the ClassOfOrdinaryBiologicalObject.
+     * @return A ClassOfOrdinaryBiologicalObject instance.
+     */
+    public static ClassOfOrdinaryBiologicalObject createClassOfOrdinaryBiologicalObject(final String id) {
+        final ClassOfOrdinaryBiologicalObject result = ClassServices.createClassOfOrdinaryBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_ORDINARY_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfOrdinaryFunctionalObject} with an String.
+     *
+     * @param id ID of the ClassOfOrdinaryFunctionalObject.
+     * @return A ClassOfOrdinaryFunctionalObject instance.
+     */
+    public static ClassOfOrdinaryFunctionalObject createClassOfOrdinaryFunctionalObject(final String id) {
+        final ClassOfOrdinaryFunctionalObject result = ClassServices.createClassOfOrdinaryFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_ORDINARY_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfOrdinaryPhysicalObject} with an String.
+     *
+     * @param id ID of the ClassOfOrdinaryPhysicalObject.
+     * @return A ClassOfOrdinaryPhysicalObject instance.
+     */
+    public static ClassOfOrdinaryPhysicalObject createClassOfOrdinaryPhysicalObject(final String id) {
+        final ClassOfOrdinaryPhysicalObject result = ClassServices.createClassOfOrdinaryPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_ORDINARY_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfOrganization} with an String.
+     *
+     * @param id ID of the ClassOfOrganization.
+     * @return A ClassOfOrganization instance.
+     */
+    public static ClassOfOrganization createClassOfOrganization(final String id) {
+        final ClassOfOrganization result = ClassServices.createClassOfOrganization(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_ORGANIZATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfOrganizationComponent} with an String.
+     *
+     * @param id ID of the ClassOfOrganizationComponent.
+     * @return A ClassOfOrganizationComponent instance.
+     */
+    public static ClassOfOrganizationComponent createClassOfOrganizationComponent(final String id) {
+        final ClassOfOrganizationComponent result = ClassServices.createClassOfOrganizationComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_ORGANIZATION_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfParticipant} with an String.
+     *
+     * @param id ID of the ClassOfParticipant.
+     * @return A ClassOfParticipant instance.
+     */
+    public static ClassOfParticipant createClassOfParticipant(final String id) {
+        final ClassOfParticipant result = ClassServices.createClassOfParticipant(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_PARTICIPANT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfParty} with an String.
+     *
+     * @param id ID of the ClassOfParty.
+     * @return A ClassOfParty instance.
+     */
+    public static ClassOfParty createClassOfParty(final String id) {
+        final ClassOfParty result = ClassServices.createClassOfParty(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_PARTY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPeriodOfTime} with an String.
+     *
+     * @param id ID of the ClassOfPeriodOfTime.
+     * @return A ClassOfPeriodOfTime instance.
+     */
+    public static ClassOfPeriodOfTime createClassOfPeriodOfTime(final String id) {
+        final ClassOfPeriodOfTime result = ClassServices.createClassOfPeriodOfTime(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_PERIOD_OF_TIME);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPerson} with an String.
+     *
+     * @param id ID of the ClassOfPerson.
+     * @return A ClassOfPerson instance.
+     */
+    public static ClassOfPerson createClassOfPerson(final String id) {
+        final ClassOfPerson result = ClassServices.createClassOfPerson(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_PERSON);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPersonInPosition} with an String.
+     *
+     * @param id ID of the ClassOfPersonInPosition.
+     * @return A ClassOfPersonInPosition instance.
+     */
+    public static ClassOfPersonInPosition createClassOfPersonInPosition(final String id) {
+        final ClassOfPersonInPosition result = ClassServices.createClassOfPersonInPosition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_PERSON_IN_POSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPhysicalObject} with an String.
+     *
+     * @param id ID of the ClassOfPhysicalObject.
+     * @return A ClassOfPhysicalObject instance.
+     */
+    public static ClassOfPhysicalObject createClassOfPhysicalObject(final String id) {
+        final ClassOfPhysicalObject result = ClassServices.createClassOfPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPhysicalProperty} with an String.
+     *
+     * @param id ID of the ClassOfPhysicalProperty.
+     * @return A ClassOfPhysicalProperty instance.
+     */
+    public static ClassOfPhysicalProperty createClassOfPhysicalProperty(final String id) {
+        final ClassOfPhysicalProperty result = ClassServices.createClassOfPhysicalProperty(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_PHYSICAL_PROPERTY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPhysicalQuantity} with an String.
+     *
+     * @param id ID of the ClassOfPhysicalQuantity.
+     * @return A ClassOfPhysicalQuantity instance.
+     */
+    public static ClassOfPhysicalQuantity createClassOfPhysicalQuantity(final String id) {
+        final ClassOfPhysicalQuantity result = ClassServices.createClassOfPhysicalQuantity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_PHYSICAL_QUANTITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPointInTime} with an String.
+     *
+     * @param id ID of the ClassOfPointInTime.
+     * @return A ClassOfPointInTime instance.
+     */
+    public static ClassOfPointInTime createClassOfPointInTime(final String id) {
+        final ClassOfPointInTime result = ClassServices.createClassOfPointInTime(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_POINT_IN_TIME);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPosition} with an String.
+     *
+     * @param id ID of the ClassOfPosition.
+     * @return A ClassOfPosition instance.
+     */
+    public static ClassOfPosition createClassOfPosition(final String id) {
+        final ClassOfPosition result = ClassServices.createClassOfPosition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_POSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfPossibleWorld} with an String.
+     *
+     * @param id ID of the ClassOfPossibleWorld.
+     * @return A ClassOfPossibleWorld instance.
+     */
+    public static ClassOfPossibleWorld createClassOfPossibleWorld(final String id) {
+        final ClassOfPossibleWorld result = ClassServices.createClassOfPossibleWorld(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_POSSIBLE_WORLD);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfReachingAgreement} with an String.
+     *
+     * @param id ID of the ClassOfReachingAgreement.
+     * @return A ClassOfReachingAgreement instance.
+     */
+    public static ClassOfReachingAgreement createClassOfReachingAgreement(final String id) {
+        final ClassOfReachingAgreement result = ClassServices.createClassOfReachingAgreement(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_REACHING_AGREEMENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfRelationship} with an String.
+     *
+     * @param id ID of the ClassOfRelationship.
+     * @return A ClassOfRelationship instance.
+     */
+    public static ClassOfRelationship createClassOfRelationship(final String id) {
+        final ClassOfRelationship result = ClassServices.createClassOfRelationship(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_RELATIONSHIP);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfRepresentation} with an String.
+     *
+     * @param id ID of the ClassOfRepresentation.
+     * @return A ClassOfRepresentation instance.
+     */
+    public static ClassOfRepresentation createClassOfRepresentation(final String id) {
+        final ClassOfRepresentation result = ClassServices.createClassOfRepresentation(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_REPRESENTATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfSalesProductInstance} with an String.
+     *
+     * @param id ID of the ClassOfSalesProductInstance.
+     * @return A ClassOfSalesProductInstance instance.
+     */
+    public static ClassOfSalesProductInstance createClassOfSalesProductInstance(final String id) {
+        final ClassOfSalesProductInstance result = ClassServices.createClassOfSalesProductInstance(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_SALES_PRODUCT_INSTANCE);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfSign} with an String.
+     *
+     * @param id ID of the ClassOfSign.
+     * @return A ClassOfSign instance.
+     */
+    public static ClassOfSign createClassOfSign(final String id) {
+        final ClassOfSign result = ClassServices.createClassOfSign(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_SIGN);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfSociallyConstructedActivity} with an String.
+     *
+     * @param id ID of the ClassOfSociallyConstructedActivity.
+     * @return A ClassOfSociallyConstructedActivity instance.
+     */
+    public static ClassOfSociallyConstructedActivity createClassOfSociallyConstructedActivity(final String id) {
+        final ClassOfSociallyConstructedActivity result = ClassServices.createClassOfSociallyConstructedActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_SOCIALLY_CONSTRUCTED_ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfSociallyConstructedObject} with an String.
+     *
+     * @param id ID of the ClassOfSociallyConstructedObject.
+     * @return A ClassOfSociallyConstructedObject instance.
+     */
+    public static ClassOfSociallyConstructedObject createClassOfSociallyConstructedObject(final String id) {
+        final ClassOfSociallyConstructedObject result = ClassServices.createClassOfSociallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_SOCIALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfSpatioTemporalExtent} with an String.
+     *
+     * @param id ID of the ClassOfSpatioTemporalExtent.
+     * @return A ClassOfSpatioTemporalExtent instance.
+     */
+    public static ClassOfSpatioTemporalExtent createClassOfSpatioTemporalExtent(final String id) {
+        final ClassOfSpatioTemporalExtent result = ClassServices.createClassOfSpatioTemporalExtent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_SPATIO_TEMPORAL_EXTENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfState} with an String.
+     *
+     * @param id ID of the ClassOfState.
+     * @return A ClassOfState instance.
+     */
+    public static ClassOfState createClassOfState(final String id) {
+        final ClassOfState result = ClassServices.createClassOfState(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfActivity} with an String.
+     *
+     * @param id ID of the ClassOfStateOfActivity.
+     * @return A ClassOfStateOfActivity instance.
+     */
+    public static ClassOfStateOfActivity createClassOfStateOfActivity(final String id) {
+        final ClassOfStateOfActivity result = ClassServices.createClassOfStateOfActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfAmountOfMoney} with an String.
+     *
+     * @param id ID of the ClassOfStateOfAmountOfMoney.
+     * @return A ClassOfStateOfAmountOfMoney instance.
+     */
+    public static ClassOfStateOfAmountOfMoney createClassOfStateOfAmountOfMoney(final String id) {
+        final ClassOfStateOfAmountOfMoney result = ClassServices.createClassOfStateOfAmountOfMoney(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_AMOUNT_OF_MONEY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfAssociation} with an String.
+     *
+     * @param id ID of the ClassOfStateOfAssociation.
+     * @return A ClassOfStateOfAssociation instance.
+     */
+    public static ClassOfStateOfAssociation createClassOfStateOfAssociation(final String id) {
+        final ClassOfStateOfAssociation result = ClassServices.createClassOfStateOfAssociation(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_ASSOCIATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfBiologicalObject} with an String.
+     *
+     * @param id ID of the ClassOfStateOfBiologicalObject.
+     * @return A ClassOfStateOfBiologicalObject instance.
+     */
+    public static ClassOfStateOfBiologicalObject createClassOfStateOfBiologicalObject(final String id) {
+        final ClassOfStateOfBiologicalObject result = ClassServices.createClassOfStateOfBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfBiologicalSystem} with an String.
+     *
+     * @param id ID of the ClassOfStateOfBiologicalSystem.
+     * @return A ClassOfStateOfBiologicalSystem instance.
+     */
+    public static ClassOfStateOfBiologicalSystem createClassOfStateOfBiologicalSystem(final String id) {
+        final ClassOfStateOfBiologicalSystem result = ClassServices.createClassOfStateOfBiologicalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_BIOLOGICAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfBiologicalSystemComponent} with an String.
+     *
+     * @param id ID of the ClassOfStateOfBiologicalSystemComponent.
+     * @return A ClassOfStateOfBiologicalSystemComponent instance.
+     */
+    public static ClassOfStateOfBiologicalSystemComponent createClassOfStateOfBiologicalSystemComponent(
+            final String id) {
+        final ClassOfStateOfBiologicalSystemComponent result = ClassServices
+                .createClassOfStateOfBiologicalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_BIOLOGICAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfFunctionalObject} with an String.
+     *
+     * @param id ID of the ClassOfStateOfFunctionalObject.
+     * @return A ClassOfStateOfFunctionalObject instance.
+     */
+    public static ClassOfStateOfFunctionalObject createClassOfStateOfFunctionalObject(final String id) {
+        final ClassOfStateOfFunctionalObject result = ClassServices.createClassOfStateOfFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfFunctionalSystem} with an String.
+     *
+     * @param id ID of the ClassOfStateOfFunctionalSystem.
+     * @return A ClassOfStateOfFunctionalSystem instance.
+     */
+    public static ClassOfStateOfFunctionalSystem createClassOfStateOfFunctionalSystem(final String id) {
+        final ClassOfStateOfFunctionalSystem result = ClassServices.createClassOfStateOfFunctionalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfFunctionalSystemComponent} with an String.
+     *
+     * @param id ID of the ClassOfStateOfFunctionalSystemComponent.
+     * @return A ClassOfStateOfFunctionalSystemComponent instance.
+     */
+
+    public static ClassOfStateOfFunctionalSystemComponent createClassOfStateOfFunctionalSystemComponent(
+            final String id) {
+        final ClassOfStateOfFunctionalSystemComponent result = ClassServices
+                .createClassOfStateOfFunctionalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_FUNCTIONAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfIntentionallyConstructedObject} with an String.
+     *
+     * @param id ID of the ClassOfStateOfIntentionallyConstructedObject.
+     * @return A ClassOfStateOfIntentionallyConstructedObject instance.
+     */
+
+    public static ClassOfStateOfIntentionallyConstructedObject createClassOfStateOfIntentionallyConstructedObject(
+            final String id) {
+        final ClassOfStateOfIntentionallyConstructedObject result = ClassServices
+                .createClassOfStateOfIntentionallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE,
+                HQDM.CLASS_OF_STATE_OF_INTENTIONALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfOrdinaryBiologicalObject} with an String.
+     *
+     * @param id ID of the ClassOfStateOfOrdinaryBiologicalObject.
+     * @return A ClassOfStateOfOrdinaryBiologicalObject instance.
+     */
+    public static ClassOfStateOfOrdinaryBiologicalObject createClassOfStateOfOrdinaryBiologicalObject(final String id) {
+        final ClassOfStateOfOrdinaryBiologicalObject result = ClassServices
+                .createClassOfStateOfOrdinaryBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_ORDINARY_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfOrdinaryFunctionalObject} with an Stri ng.
+     *
+     * @param id ID of the ClassOfStateOfOrdinaryFunctionalObject.
+     * @return A ClassOfStateOfOrdinaryFunctionalObject instance.
+     */
+    public static ClassOfStateOfOrdinaryFunctionalObject createClassOfStateOfOrdinaryFunctionalObject(final String id) {
+        final ClassOfStateOfOrdinaryFunctionalObject result = ClassServices
+                .createClassOfStateOfOrdinaryFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_ORDINARY_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfOrdinaryPhysicalObject} with an String.
+     *
+     * @param id ID of the ClassOfStateOfOrdinaryPhysicalObject.
+     * @return A ClassOfStateOfOrdinaryPhysicalObject instance.
+     */
+    public static ClassOfStateOfOrdinaryPhysicalObject createClassOfStateOfOrdinaryPhysicalObject(final String id) {
+        final ClassOfStateOfOrdinaryPhysicalObject result = ClassServices
+                .createClassOfStateOfOrdinaryPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_ORDINARY_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfOrganization} with an String.
+     *
+     * @param id ID of the ClassOfStateOfOrganization.
+     * @return A ClassOfStateOfOrganization instance.
+     */
+    public static ClassOfStateOfOrganization createClassOfStateOfOrganization(final String id) {
+        final ClassOfStateOfOrganization result = ClassServices.createClassOfStateOfOrganization(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_ORGANIZATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfOrganizationComponent} with an String.
+     *
+     * @param id ID of the ClassOfStateOfOrganizationComponent.
+     * @return A ClassOfStateOfOrganizationComponent instance.
+     */
+    public static ClassOfStateOfOrganizationComponent createClassOfStateOfOrganizationComponent(final String id) {
+        final ClassOfStateOfOrganizationComponent result = ClassServices.createClassOfStateOfOrganizationComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_ORGANIZATION_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfParty} with an String.
+     *
+     * @param id ID of the ClassOfStateOfParty.
+     * @return A ClassOfStateOfParty instance.
+     */
+    public static ClassOfStateOfParty createClassOfStateOfParty(final String id) {
+        final ClassOfStateOfParty result = ClassServices.createClassOfStateOfParty(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_PARTY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfPerson} with an String.
+     *
+     * @param id ID of the ClassOfStateOfPerson.
+     * @return A ClassOfStateOfPerson instance.
+     */
+    public static ClassOfStateOfPerson createClassOfStateOfPerson(final String id) {
+        final ClassOfStateOfPerson result = ClassServices.createClassOfStateOfPerson(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_PERSON);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfPhysicalObject} with an String.
+     *
+     * @param id ID of the ClassOfStateOfPhysicalObject.
+     * @return A ClassOfStateOfPhysicalObject instance.
+     */
+    public static ClassOfStateOfPhysicalObject createClassOfStateOfPhysicalObject(final String id) {
+        final ClassOfStateOfPhysicalObject result = ClassServices.createClassOfStateOfPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfPosition} with an String.
+     *
+     * @param id ID of the ClassOfStateOfPosition.
+     * @return A ClassOfStateOfPosition instance.
+     */
+    public static ClassOfStateOfPosition createClassOfStateOfPosition(final String id) {
+        final ClassOfStateOfPosition result = ClassServices.createClassOfStateOfPosition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_POSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfSalesProductInstance} with an String.
+     *
+     * @param id ID of the ClassOfStateOfSalesProductInstance.
+     * @return A ClassOfStateOfSalesProductInstance instance.
+     */
+    public static ClassOfStateOfSalesProductInstance createClassOfStateOfSalesProductInstance(final String id) {
+        final ClassOfStateOfSalesProductInstance result = ClassServices.createClassOfStateOfSalesProductInstance(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_SALES_PRODUCT_INSTANCE);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfSign} with an String.
+     *
+     * @param id ID of the ClassOfStateOfSign.
+     * @return A ClassOfStateOfSign instance.
+     */
+    public static ClassOfStateOfSign createClassOfStateOfSign(final String id) {
+        final ClassOfStateOfSign result = ClassServices.createClassOfStateOfSign(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_SIGN);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfSociallyConstructedActivity} with an String.
+     *
+     * @param id ID of the ClassOfStateOfSociallyConstructedActivity.
+     * @return A ClassOfStateOfSociallyConstructedActivity instance.
+     */
+    public static ClassOfStateOfSociallyConstructedActivity createClassOfStateOfSociallyConstructedActivity(
+            final String id) {
+        final ClassOfStateOfSociallyConstructedActivity result = ClassServices
+                .createClassOfStateOfSociallyConstructedActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_SOCIALLY_CONSTRUCTED_ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfSociallyConstructedObject} with an String.
+     *
+     * @param id ID of the ClassOfStateOfSociallyConstructedObject.
+     * @return A ClassOfStateOfSociallyConstructedObject instance.
+     */
+    public static ClassOfStateOfSociallyConstructedObject createClassOfStateOfSociallyConstructedObject(
+            final String id) {
+        final ClassOfStateOfSociallyConstructedObject result = ClassServices
+                .createClassOfStateOfSociallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_SOCIALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfSystem} with an String.
+     *
+     * @param id ID of the ClassOfStateOfSystem.
+     * @return A ClassOfStateOfSystem instance.
+     */
+    public static ClassOfStateOfSystem createClassOfStateOfSystem(final String id) {
+        final ClassOfStateOfSystem result = ClassServices.createClassOfStateOfSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfStateOfSystemComponent} with an String.
+     *
+     * @param id ID of the ClassOfStateOfSystemComponent.
+     * @return A ClassOfStateOfSystemComponent instance.
+     */
+    public static ClassOfStateOfSystemComponent createClassOfStateOfSystemComponent(final String id) {
+        final ClassOfStateOfSystemComponent result = ClassServices.createClassOfStateOfSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_STATE_OF_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfSystem} with an String.
+     *
+     * @param id ID of the ClassOfSystem.
+     * @return A ClassOfSystem instance.
+     */
+    public static ClassOfSystem createClassOfSystem(final String id) {
+        final ClassOfSystem result = ClassServices.createClassOfSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link ClassOfSystemComponent} with an String.
+     *
+     * @param id ID of the ClassOfSystemComponent.
+     * @return A ClassOfSystemComponent instance.
+     */
+    public static ClassOfSystemComponent createClassOfSystemComponent(final String id) {
+        final ClassOfSystemComponent result = ClassServices.createClassOfSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASS_OF_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfActivity} with an String.
+     *
+     * @param id ID of the KindOfActivity.
+     * @return A KindOfActivity instance.
+     */
+    public static KindOfActivity createKindOfActivity(final String id) {
+        final KindOfActivity result = ClassServices.createKindOfActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfAssociation} with an String.
+     *
+     * @param id ID of the KindOfAssociation.
+     * @return A KindOfAssociation instance.
+     */
+    public static KindOfAssociation createKindOfAssociation(final String id) {
+        final KindOfAssociation result = ClassServices.createKindOfAssociation(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_ASSOCIATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfBiologicalObject} with an String.
+     *
+     * @param id ID of the KindOfBiologicalObject.
+     * @return A KindOfBiologicalObject instance.
+     */
+    public static KindOfBiologicalObject createKindOfBiologicalObject(final String id) {
+        final KindOfBiologicalObject result = ClassServices.createKindOfBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfBiologicalSystem} with an String.
+     *
+     * @param id ID of the KindOfBiologicalSystem.
+     * @return A KindOfBiologicalSystem instance.
+     */
+    public static KindOfBiologicalSystem createKindOfBiologicalSystem(final String id) {
+        final KindOfBiologicalSystem result = ClassServices.createKindOfBiologicalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_BIOLOGICAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfBiologicalSystemComponent} with an String.
+     *
+     * @param id ID of the KindOfBiologicalSystemComponent.
+     * @return A KindOfBiologicalSystemComponent instance.
+     */
+    public static KindOfBiologicalSystemComponent createKindOfBiologicalSystemComponent(final String id) {
+        final KindOfBiologicalSystemComponent result = ClassServices.createKindOfBiologicalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_BIOLOGICAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfFunctionalObject} with an String.
+     *
+     * @param id ID of the KindOfFunctionalObject.
+     * @return A KindOfFunctionalObject instance.
+     */
+    public static KindOfFunctionalObject createKindOfFunctionalObject(final String id) {
+        final KindOfFunctionalObject result = ClassServices.createKindOfFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfFunctionalSystem} with an String.
+     *
+     * @param id ID of the KindOfFunctionalSystem.
+     * @return A KindOfFunctionalSystem instance.
+     */
+    public static KindOfFunctionalSystem createKindOfFunctionalSystem(final String id) {
+        final KindOfFunctionalSystem result = ClassServices.createKindOfFunctionalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_FUNCTIONAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfFunctionalSystemComponent} with an String.
+     *
+     * @param id ID of the KindOfFunctionalSystemComponent.
+     * @return A KindOfFunctionalSystemComponent instance.
+     */
+    public static KindOfFunctionalSystemComponent createKindOfFunctionalSystemComponent(final String id) {
+        final KindOfFunctionalSystemComponent result = ClassServices.createKindOfFunctionalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_FUNCTIONAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfIndividual} with an String.
+     *
+     * @param id ID of the KindOfIndividual.
+     * @return A KindOfIndividual instance.
+     */
+    public static KindOfIndividual createKindOfIndividual(final String id) {
+        final KindOfIndividual result = ClassServices.createKindOfIndividual(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_INDIVIDUAL);
+        return result;
+
+    }
+
+    /**
+     * Create a {@link KindOfIntentionallyConstructedObject} with an String.
+     *
+     * @param id ID of the KindOfIntentionallyConstructedObject.
+     * @return A KindOfIntentionallyConstructedObject instance.
+     */
+    public static KindOfIntentionallyConstructedObject createKindOfIntentionallyConstructedObject(final String id) {
+        final KindOfIntentionallyConstructedObject result = ClassServices
+                .createKindOfIntentionallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_INTENTIONALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfOrdinaryBiologicalObject} with an String.
+     *
+     * @param id ID of the KindOfOrdinaryBiologicalObject.
+     * @return A KindOfOrdinaryBiologicalObject instance.
+     */
+    public static KindOfOrdinaryBiologicalObject createKindOfOrdinaryBiologicalObject(final String id) {
+        final KindOfOrdinaryBiologicalObject result = ClassServices.createKindOfOrdinaryBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_ORDINARY_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfOrdinaryFunctionalObject} with an String.
+     *
+     * @param id ID of the KindOfOrdinaryFunctionalObject.
+     * @return A KindOfOrdinaryFunctionalObject instance.
+     */
+    public static KindOfOrdinaryFunctionalObject createKindOfOrdinaryFunctionalObject(final String id) {
+        final KindOfOrdinaryFunctionalObject result = ClassServices.createKindOfOrdinaryFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_ORDINARY_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfOrdinaryPhysicalObject} with an String.
+     *
+     * @param id ID of the KindOfOrdinaryPhysicalObject.
+     * @return A KindOfOrdinaryPhysicalObject instance.
+     */
+    public static KindOfOrdinaryPhysicalObject createKindOfOrdinaryPhysicalObject(final String id) {
+        final KindOfOrdinaryPhysicalObject result = ClassServices.createKindOfOrdinaryPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_ORDINARY_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfOrganization} with an String.
+     *
+     * @param id ID of the KindOfOrganization.
+     * @return A KindOfOrganization instance.
+     */
+    public static KindOfOrganization createKindOfOrganization(final String id) {
+        final KindOfOrganization result = ClassServices.createKindOfOrganization(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_ORGANIZATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfOrganizationComponent} with an String.
+     *
+     * @param id ID of the KindOfOrganizationComponent.
+     * @return A KindOfOrganizationComponent instance.
+     */
+    public static KindOfOrganizationComponent createKindOfOrganizationComponent(final String id) {
+        final KindOfOrganizationComponent result = ClassServices.createKindOfOrganizationComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_ORGANIZATION_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfParty} with an String.
+     *
+     * @param id ID of the KindOfParty.
+     * @return A KindOfParty instance.
+     */
+    public static KindOfParty createKindOfParty(final String id) {
+        final KindOfParty result = ClassServices.createKindOfParty(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_PARTY);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfPerson} with an String.
+     *
+     * @param id ID of the KindOfPerson.
+     * @return A KindOfPerson instance.
+     */
+    public static KindOfPerson createKindOfPerson(final String id) {
+        final KindOfPerson result = ClassServices.createKindOfPerson(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_PERSON);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfPhysicalObject} with an String.
+     *
+     * @param id ID of the KindOfPhysicalObject.
+     * @return A KindOfPhysicalObject instance.
+     */
+    public static KindOfPhysicalObject createKindOfPhysicalObject(final String id) {
+        final KindOfPhysicalObject result = ClassServices.createKindOfPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfPhysicalProperty} with an String.
+     *
+     * @param id ID of the KindOfPhysicalProperty.
+     * @return A KindOfPhysicalProperty instance.
+     */
+    public static KindOfPhysicalProperty createKindOfPhysicalProperty(final String id) {
+        final KindOfPhysicalProperty result = ClassServices.createKindOfPhysicalProperty(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_PHYSICAL_PROPERTY);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfPhysicalQuantity} with an String.
+     *
+     * @param id ID of the KindOfPhysicalQuantity.
+     * @return A KindOfPhysicalQuantity instance.
+     */
+    public static KindOfPhysicalQuantity createKindOfPhysicalQuantity(final String id) {
+        final KindOfPhysicalQuantity result = ClassServices.createKindOfPhysicalQuantity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_PHYSICAL_QUANTITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfPosition} with an String.
+     *
+     * @param id ID of the KindOfPosition.
+     * @return A KindOfPosition instance.
+     */
+    public static KindOfPosition createKindOfPosition(final String id) {
+        final KindOfPosition result = ClassServices.createKindOfPosition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_POSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfRelationshipWithRestriction} with an String.
+     *
+     * @param id ID of the KindOfRelationshipWithRestriction.
+     * @return A KindOfRelationshipWithRestriction instance.
+     */
+    public static KindOfRelationshipWithRestriction createKindOfRelationshipWithRestriction(final String id) {
+        final KindOfRelationshipWithRestriction result = ClassServices.createKindOfRelationshipWithRestriction(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_RELATIONSHIP_WITH_RESTRICTION);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfRelationshipWithSignature} with an String.
+     *
+     * @param id ID of the KindOfRelationshipWithSignature.
+     * @return A KindOfRelationshipWithSignature instance.
+     */
+    public static KindOfRelationshipWithSignature createKindOfRelationshipWithSignature(final String id) {
+        final KindOfRelationshipWithSignature result = ClassServices.createKindOfRelationshipWithSignature(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_RELATIONSHIP_WITH_SIGNATURE);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfSociallyConstructedObject} with an String.
+     *
+     * @param id ID of the KindOfSociallyConstructedObject.
+     * @return A KindOfSociallyConstructedObject instance.
+     */
+    public static KindOfSociallyConstructedObject createKindOfSociallyConstructedObject(final String id) {
+        final KindOfSociallyConstructedObject result = ClassServices.createKindOfSociallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_SOCIALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfSystem} with an String.
+     *
+     * @param id ID of the KindOfSystem.
+     * @return A KindOfSystem instance.
+     */
+    public static KindOfSystem createKindOfSystem(final String id) {
+        final KindOfSystem result = ClassServices.createKindOfSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link KindOfSystemComponent} with an String.
+     *
+     * @param id ID of the KindOfSystemComponent.
+     * @return A KindOfSystemComponent instance.
+     */
+    public static KindOfSystemComponent createKindOfSystemComponent(final String id) {
+        final KindOfSystemComponent result = ClassServices.createKindOfSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.KIND_OF_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link Role} with an String.
+     *
+     * @param id ID of the Role.
+     * @return A Role instance.
+     */
+    public static Role createRole(final String id) {
+        final Role result = ClassServices.createRole(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ROLE);
+        return result;
+    }
+}

--- a/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfRelationshipServices.java
+++ b/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfRelationshipServices.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package uk.gov.gchq.magmacore.hqdm.rdfservices;
+
+import uk.gov.gchq.magmacore.hqdm.model.Aggregation;
+import uk.gov.gchq.magmacore.hqdm.model.Classification;
+import uk.gov.gchq.magmacore.hqdm.model.Composition;
+import uk.gov.gchq.magmacore.hqdm.model.DefinedRelationship;
+import uk.gov.gchq.magmacore.hqdm.model.Function_;
+import uk.gov.gchq.magmacore.hqdm.model.Relationship;
+import uk.gov.gchq.magmacore.hqdm.model.Scale;
+import uk.gov.gchq.magmacore.hqdm.model.Specialization;
+import uk.gov.gchq.magmacore.hqdm.model.TemporalComposition;
+import uk.gov.gchq.magmacore.hqdm.model.UnitOfMeasure;
+import uk.gov.gchq.magmacore.hqdm.rdf.iri.HQDM;
+import uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS;
+import uk.gov.gchq.magmacore.hqdm.services.RelationshipServices;
+
+/**
+ * Service for creating HQDM Relationships.
+ */
+public class RdfRelationshipServices {
+    /**
+     * Create a {@link Specialization} with an String.
+     *
+     * @param id ID of the Specialization.
+     * @return A Specialization instance.
+     */
+    public static Specialization createSpecialization(final String id) {
+        final Specialization result = RelationshipServices.createSpecialization(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SPECIALIZATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link Scale} with an String.
+     *
+     * @param id ID of the Scale.
+     * @return A Scale instance.
+     */
+    public static Scale createScale(final String id) {
+        final Scale result = RelationshipServices.createScale(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SCALE);
+        return result;
+    }
+
+    /**
+     * Create a {@link UnitOfMeasure} with an String.
+     *
+     * @param id ID of the UnitOfMeasure.
+     * @return A UnitOfMeasure instance.
+     */
+    public static UnitOfMeasure createUnitOfMeasure(final String id) {
+        final UnitOfMeasure result = RelationshipServices.createUnitOfMeasure(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.UNIT_OF_MEASURE);
+        return result;
+    }
+
+    /**
+     * Create a {@link Function_} with an String.
+     *
+     * @param id ID of the Function_.
+     * @return A Function_ instance.
+     */
+    public static Function_ createFunction(final String id) {
+        final Function_ result = RelationshipServices.createFunction(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.FUNCTION_);
+        return result;
+    }
+
+    /**
+     * Create a {@link Classification} with an String.
+     *
+     * @param id ID of the Classification.
+     * @return A Classification instance.
+     */
+    public static Classification createClassification(final String id) {
+        final Classification result = RelationshipServices.createClassification(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CLASSIFICATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link TemporalComposition} with an String.
+     *
+     * @param id ID of the TemporalComposition.
+     * @return A TemporalComposition instance.
+     */
+    public static TemporalComposition createTemporalComposition(final String id) {
+        final TemporalComposition result = RelationshipServices.createTemporalComposition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.TEMPORAL_COMPOSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link Composition} with an String.
+     *
+     * @param id ID of the Composition.
+     * @return A Composition instance.
+     */
+    public static Composition createComposition(final String id) {
+        final Composition result = RelationshipServices.createComposition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.COMPOSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link Aggregation} with an String.
+     *
+     * @param id ID of the Aggregation.
+     * @return A Aggregation instance.
+     */
+    public static Aggregation createAggregation(final String id) {
+        final Aggregation result = RelationshipServices.createAggregation(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.AGGREGATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link Relationship} with an String.
+     *
+     * @param id ID of the Relationship.
+     * @return A Relationship instance.
+     */
+    public static Relationship createRelationship(final String id) {
+        final Relationship result = RelationshipServices.createRelationship(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.RELATIONSHIP);
+        return result;
+    }
+
+    /**
+     * Create a {@link DefinedRelationship} with an String.
+     *
+     * @param id ID of the DefinedRelationship.
+     * @return A DefinedRelationship instance.
+     */
+    public static DefinedRelationship createDefinedRelationship(final String id) {
+        final DefinedRelationship result = RelationshipServices.createDefinedRelationship(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.DEFINED_RELATIONSHIP);
+        return result;
+    }
+}

--- a/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfSpatioTemporalExtentServices.java
+++ b/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfSpatioTemporalExtentServices.java
@@ -1,0 +1,1418 @@
+/*
+ * Copyright 2021 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package uk.gov.gchq.magmacore.hqdm.rdfservices;
+
+import uk.gov.gchq.magmacore.hqdm.model.*;
+import uk.gov.gchq.magmacore.hqdm.rdf.iri.HQDM;
+import uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS;
+import uk.gov.gchq.magmacore.hqdm.services.SpatioTemporalExtentServices;
+
+/**
+ * Services for creating SpatioTemporalExtent objects.
+ */
+public class RdfSpatioTemporalExtentServices {
+
+    /**
+     * Create a {@link AbstractObject} with an String.
+     *
+     * @param id ID of the AbstractObject.
+     * @return A AbstractObject instance.
+     */
+    public static AbstractObject createAbstractObject(final String id) {
+        final AbstractObject result = SpatioTemporalExtentServices.createAbstractObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ABSTRACT_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link AcceptanceOfOffer} with an String.
+     *
+     * @param id ID of the AcceptanceOfOffer.
+     * @return A AcceptanceOfOffer instance.
+     */
+    public static AcceptanceOfOffer createAcceptanceOfOffer(final String id) {
+        final AcceptanceOfOffer result = SpatioTemporalExtentServices.createAcceptanceOfOffer(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ACCEPTANCE_OF_OFFER);
+        return result;
+    }
+
+    /**
+     * Create a {@link AcceptanceOfOfferForGoods} with an String.
+     *
+     * @param id ID of the AcceptanceOfOfferForGoods.
+     * @return A AcceptanceOfOfferForGoods instance.
+     */
+    public static AcceptanceOfOfferForGoods createAcceptanceOfOfferForGoods(final String id) {
+        final AcceptanceOfOfferForGoods result = SpatioTemporalExtentServices.createAcceptanceOfOfferForGoods(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ACCEPTANCE_OF_OFFER_FOR_GOODS);
+        return result;
+    }
+
+    /**
+     * Create a {@link Activity} with an String.
+     *
+     * @param id ID of the Activity.
+     * @return A Activity instance.
+     */
+    public static Activity createActivity(final String id) {
+        final Activity result = SpatioTemporalExtentServices.createActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link AgreeContract} with an String.
+     *
+     * @param id ID of the AgreeContract.
+     * @return A AgreeContract instance.
+     */
+    public static AgreeContract createAgreeContract(final String id) {
+        final AgreeContract result = SpatioTemporalExtentServices.createAgreeContract(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.AGREE_CONTRACT);
+        return result;
+    }
+
+    /**
+     * Create a {@link AgreementExecution} with an String.
+     *
+     * @param id ID of the AgreementExecution.
+     * @return A AgreementExecution instance.
+     */
+    public static AgreementExecution createAgreementExecution(final String id) {
+        final AgreementExecution result = SpatioTemporalExtentServices.createAgreementExecution(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.AGREEMENT_EXECUTION);
+        return result;
+    }
+
+    /**
+     * Create a {@link AgreementProcess} with an String.
+     *
+     * @param id ID of the AgreementProcess.
+     * @return A AgreementProcess instance.
+     */
+    public static AgreementProcess createAgreementProcess(final String id) {
+        final AgreementProcess result = SpatioTemporalExtentServices.createAgreementProcess(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.AGREEMENT_PROCESS);
+        return result;
+    }
+
+    /**
+     * Create a {@link AmountOfMoney} with an String.
+     *
+     * @param id ID of the AmountOfMoney.
+     * @return A AmountOfMoney instance.
+     */
+    public static AmountOfMoney createAmountOfMoney(final String id) {
+        final AmountOfMoney result = SpatioTemporalExtentServices.createAmountOfMoney(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.AMOUNT_OF_MONEY);
+        return result;
+    }
+
+    /**
+     * Create a {@link Asset} with an String.
+     *
+     * @param id ID of the Asset.
+     * @return A Asset instance.
+     */
+    public static Asset createAsset(final String id) {
+        final Asset result = SpatioTemporalExtentServices.createAsset(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ASSET);
+        return result;
+    }
+
+    /**
+     * Create a {@link Association} with an String.
+     *
+     * @param id ID of the Association.
+     * @return A Association instance.
+     */
+    public static Association createAssociation(final String id) {
+        final Association result = SpatioTemporalExtentServices.createAssociation(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ASSOCIATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link BeginningOfOwnership} with an String.
+     *
+     * @param id ID of the BeginningOfOwnership.
+     * @return A BeginningOfOwnership instance.
+     */
+    public static BeginningOfOwnership createBeginningOfOwnership(final String id) {
+        final BeginningOfOwnership result = SpatioTemporalExtentServices.createBeginningOfOwnership(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.BEGINNING_OF_OWNERSHIP);
+        return result;
+    }
+
+    /**
+     * Create a {@link BiologicalObject} with an String.
+     *
+     * @param id ID of the BiologicalObject.
+     * @return A BiologicalObject instance.
+     */
+    public static BiologicalObject createBiologicalObject(final String id) {
+        final BiologicalObject result = SpatioTemporalExtentServices.createBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link BiologicalSystem} with an String.
+     *
+     * @param id ID of the BiologicalSystem.
+     * @return A BiologicalSystem instance.
+     */
+    public static BiologicalSystem createBiologicalSystem(final String id) {
+        final BiologicalSystem result = SpatioTemporalExtentServices.createBiologicalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.BIOLOGICAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link BiologicalSystemComponent} with an String.
+     *
+     * @param id ID of the BiologicalSystemComponent.
+     * @return A BiologicalSystemComponent instance.
+     */
+    public static BiologicalSystemComponent createBiologicalSystemComponent(final String id) {
+        final BiologicalSystemComponent result = SpatioTemporalExtentServices.createBiologicalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.BIOLOGICAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ContractExecution} with an String.
+     *
+     * @param id ID of the ContractExecution.
+     * @return A ContractExecution instance.
+     */
+    public static ContractExecution createContractExecution(final String id) {
+        final ContractExecution result = SpatioTemporalExtentServices.createContractExecution(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CONTRACT_EXECUTION);
+        return result;
+    }
+
+    /**
+     * Create a {@link ContractProcess} with an String.
+     *
+     * @param id ID of the ContractProcess.
+     * @return A ContractProcess instance.
+     */
+    public static ContractProcess createContractProcess(final String id) {
+        final ContractProcess result = SpatioTemporalExtentServices.createContractProcess(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CONTRACT_PROCESS);
+        return result;
+    }
+
+    /**
+     * Create a {@link Currency} with an String.
+     *
+     * @param id ID of the Currency.
+     * @return A Currency instance.
+     */
+    public static Currency createCurrency(final String id) {
+        final Currency result = SpatioTemporalExtentServices.createCurrency(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.CURRENCY);
+        return result;
+    }
+
+    /**
+     * Create a {@link Definition} with an String.
+     *
+     * @param id ID of the Definition.
+     * @return A Definition instance.
+     */
+    public static Definition createDefinition(final String id) {
+        final Definition result = SpatioTemporalExtentServices.createDefinition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.DEFINITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link Description} with an String.
+     *
+     * @param id ID of the Description.
+     * @return A Description instance.
+     */
+    public static Description createDescription(final String id) {
+        final Description result = SpatioTemporalExtentServices.createDescription(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.DESCRIPTION);
+        return result;
+    }
+
+    /**
+     * Create a {@link Employee} with an String.
+     *
+     * @param id ID of the Employee.
+     * @return A Employee instance.
+     */
+    public static Employee createEmployee(final String id) {
+        final Employee result = SpatioTemporalExtentServices.createEmployee(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.EMPLOYEE);
+        return result;
+    }
+
+    /**
+     * Create a {@link Employer} with an String.
+     *
+     * @param id ID of the Employer.
+     * @return A Employer instance.
+     */
+    public static Employer createEmployer(final String id) {
+        final Employer result = SpatioTemporalExtentServices.createEmployer(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.EMPLOYER);
+        return result;
+    }
+
+    /**
+     * Create a {@link Employment} with an String.
+     *
+     * @param id ID of the Employment.
+     * @return A Employment instance.
+     */
+    public static Employment createEmployment(final String id) {
+        final Employment result = SpatioTemporalExtentServices.createEmployment(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.EMPLOYMENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link EndingOfOwnership} with an String.
+     *
+     * @param id ID of the EndingOfOwnership.
+     * @return A EndingOfOwnership instance.
+     */
+    public static EndingOfOwnership createEndingOfOwnership(final String id) {
+        final EndingOfOwnership result = SpatioTemporalExtentServices.createEndingOfOwnership(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ENDING_OF_OWNERSHIP);
+        return result;
+    }
+
+    /**
+     * Create a {@link Event} with an String.
+     *
+     * @param id ID of the Event.
+     * @return A Event instance.
+     */
+    public static Event createEvent(final String id) {
+        final Event result = SpatioTemporalExtentServices.createEvent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.EVENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ExchangeOfGoodsAndMoney} with an String.
+     *
+     * @param id ID of the ExchangeOfGoodsAndMoney.
+     * @return A ExchangeOfGoodsAndMoney instance.
+     */
+    public static ExchangeOfGoodsAndMoney createExchangeOfGoodsAndMoney(final String id) {
+        final ExchangeOfGoodsAndMoney result = SpatioTemporalExtentServices.createExchangeOfGoodsAndMoney(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.EXCHANGE_OF_GOODS_AND_MONEY);
+        return result;
+    }
+
+    /**
+     * Create a {@link FunctionalObject} with an String.
+     *
+     * @param id ID of the FunctionalObject.
+     * @return A FunctionalObject instance.
+     */
+    public static FunctionalObject createFunctionalObject(final String id) {
+        final FunctionalObject result = SpatioTemporalExtentServices.createFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link FunctionalSystem} with an String.
+     *
+     * @param id ID of the FunctionalSystem.
+     * @return A FunctionalSystem instance.
+     */
+    public static FunctionalSystem createFunctionalSystem(final String id) {
+        final FunctionalSystem result = SpatioTemporalExtentServices.createFunctionalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.FUNCTIONAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link FunctionalSystemComponent} with an String.
+     *
+     * @param id ID of the FunctionalSystemComponent.
+     * @return A FunctionalSystemComponent instance.
+     */
+    public static FunctionalSystemComponent createFunctionalSystemComponent(final String id) {
+        final FunctionalSystemComponent result = SpatioTemporalExtentServices.createFunctionalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.FUNCTIONAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link Identification} with an String.
+     *
+     * @param id ID of the Identification.
+     * @return A Identification instance.
+     */
+    public static Identification createIdentification(final String id) {
+        final Identification result = SpatioTemporalExtentServices.createIdentification(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.IDENTIFICATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link IdentificationOfPhysicalQuantity} with an String.
+     *
+     * @param id ID of the IdentificationOfPhysicalQuantity.
+     * @return A IdentificationOfPhysicalQuantity instance.
+     */
+    public static IdentificationOfPhysicalQuantity createIdentificationOfPhysicalQuantity(final String id) {
+        final IdentificationOfPhysicalQuantity result = SpatioTemporalExtentServices
+                .createIdentificationOfPhysicalQuantity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.IDENTIFICATION_OF_PHYSICAL_QUANTITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link InPlaceBiologicalComponent} with an String.
+     *
+     * @param id ID of the InPlaceBiologicalComponent.
+     * @return A InPlaceBiologicalComponent instance.
+     */
+    public static InPlaceBiologicalComponent createInPlaceBiologicalComponent(final String id) {
+        final InPlaceBiologicalComponent result = SpatioTemporalExtentServices.createInPlaceBiologicalComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.IN_PLACE_BIOLOGICAL_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link Individual} with an String.
+     *
+     * @param id ID of the Individual.
+     * @return A Individual instance.
+     */
+    public static Individual createIndividual(final String id) {
+        final Individual result = SpatioTemporalExtentServices.createIndividual(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.INDIVIDUAL);
+        return result;
+    }
+
+    /**
+     * Create a {@link InstalledFunctionalSystemComponent} with an String.
+     *
+     * @param id ID of the InstalledFunctionalSystemComponent.
+     * @return A InstalledFunctionalSystemComponent instance.
+     */
+    public static InstalledFunctionalSystemComponent createInstalledFunctionalSystemComponent(final String id) {
+        final InstalledFunctionalSystemComponent result = SpatioTemporalExtentServices
+                .createInstalledFunctionalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.INSTALLED_FUNCTIONAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link InstalledObject} with an String.
+     *
+     * @param id ID of the InstalledObject.
+     * @return A InstalledObject instance.
+     */
+    public static InstalledObject createInstalledObject(final String id) {
+        final InstalledObject result = SpatioTemporalExtentServices.createInstalledObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.INSTALLED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link IntentionallyConstructedObject} with an String.
+     *
+     * @param id ID of the IntentionallyConstructedObject.
+     * @return A IntentionallyConstructedObject instance.
+     */
+    public static IntentionallyConstructedObject createIntentionallyConstructedObject(final String id) {
+        final IntentionallyConstructedObject result = SpatioTemporalExtentServices
+                .createIntentionallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.INTENTIONALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link LanguageCommunity} with an String.
+     *
+     * @param id ID of the LanguageCommunity.
+     * @return A LanguageCommunity instance.
+     */
+    public static LanguageCommunity createLanguageCommunity(final String id) {
+        final LanguageCommunity result = SpatioTemporalExtentServices.createLanguageCommunity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.LANGUAGE_COMMUNITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link MoneyAsset} with an String.
+     *
+     * @param id ID of the MoneyAsset.
+     * @return A MoneyAsset instance.
+     */
+    public static MoneyAsset createMoneyAsset(final String id) {
+        final MoneyAsset result = SpatioTemporalExtentServices.createMoneyAsset(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.MONEY_ASSET);
+        return result;
+    }
+
+    /**
+     * Create a {@link Offer} with an String.
+     *
+     * @param id ID of the Offer.
+     * @return A Offer instance.
+     */
+    public static Offer createOffer(final String id) {
+        final Offer result = SpatioTemporalExtentServices.createOffer(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.OFFER);
+        return result;
+    }
+
+    /**
+     * Create a {@link OfferAndAcceptanceForGoods} with an String.
+     *
+     * @param id ID of the OfferAndAcceptanceForGoods.
+     * @return A OfferAndAcceptanceForGoods instance.
+     */
+    public static OfferAndAcceptanceForGoods createOfferAndAcceptanceForGoods(final String id) {
+        final OfferAndAcceptanceForGoods result = SpatioTemporalExtentServices.createOfferAndAcceptanceForGoods(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.OFFER_AND_ACCEPTANCE_FOR_GOODS);
+        return result;
+    }
+
+    /**
+     * Create a {@link OfferForGoods} with an String.
+     *
+     * @param id ID of the OfferForGoods.
+     * @return A OfferForGoods instance.
+     */
+    public static OfferForGoods createOfferForGoods(final String id) {
+        final OfferForGoods result = SpatioTemporalExtentServices.createOfferForGoods(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.OFFER_FOR_GOODS);
+        return result;
+    }
+
+    /**
+     * Create a {@link Offering} with an String.
+     *
+     * @param id ID of the Offering.
+     * @return A Offering instance.
+     */
+    public static Offering createOffering(final String id) {
+        final Offering result = SpatioTemporalExtentServices.createOffering(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.OFFERING);
+        return result;
+    }
+
+    /**
+     * Create a {@link OrdinaryBiologicalObject} with an String.
+     *
+     * @param id ID of the OrdinaryBiologicalObject.
+     * @return A OrdinaryBiologicalObject instance.
+     */
+    public static OrdinaryBiologicalObject createOrdinaryBiologicalObject(final String id) {
+        final OrdinaryBiologicalObject result = SpatioTemporalExtentServices.createOrdinaryBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ORDINARY_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link OrdinaryFunctionalObject} with an String.
+     *
+     * @param id ID of the OrdinaryFunctionalObject.
+     * @return A OrdinaryFunctionalObject instance.
+     */
+    public static OrdinaryFunctionalObject createOrdinaryFunctionalObject(final String id) {
+        final OrdinaryFunctionalObject result = SpatioTemporalExtentServices.createOrdinaryFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ORDINARY_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link OrdinaryPhysicalObject} with an String.
+     *
+     * @param id ID of the OrdinaryPhysicalObject.
+     * @return A OrdinaryPhysicalObject instance.
+     */
+    public static OrdinaryPhysicalObject createOrdinaryPhysicalObject(final String id) {
+        final OrdinaryPhysicalObject result = SpatioTemporalExtentServices.createOrdinaryPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ORDINARY_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link Organization} with an String.
+     *
+     * @param id ID of the Organization.
+     * @return A Organization instance.
+     */
+    public static Organization createOrganization(final String id) {
+        final Organization result = SpatioTemporalExtentServices.createOrganization(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ORGANIZATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link OrganizationComponent} with an String.
+     *
+     * @param id ID of the OrganizationComponent.
+     * @return A OrganizationComponent instance.
+     */
+    public static OrganizationComponent createOrganizationComponent(final String id) {
+        final OrganizationComponent result = SpatioTemporalExtentServices.createOrganizationComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.ORGANIZATION_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link Owner} with an String.
+     *
+     * @param id ID of the Owner.
+     * @return A Owner instance.
+     */
+    public static Owner createOwner(final String id) {
+        final Owner result = SpatioTemporalExtentServices.createOwner(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.OWNER);
+        return result;
+    }
+
+    /**
+     * Create a {@link Ownership} with an String.
+     *
+     * @param id ID of the Ownership.
+     * @return A Ownership instance.
+     */
+    public static Ownership createOwnership(final String id) {
+        final Ownership result = SpatioTemporalExtentServices.createOwnership(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.OWNERSHIP);
+        return result;
+    }
+
+    /**
+     * Create a {@link Participant} with an String.
+     *
+     * @param id ID of the Participant.
+     * @return A Participant instance.
+     */
+    public static Participant createParticipant(final String id) {
+        final Participant result = SpatioTemporalExtentServices.createParticipant(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PARTICIPANT);
+        return result;
+    }
+
+    /**
+     * Create a {@link ParticipantInActivityOrAssociation} with an String.
+     *
+     * @param id ID of the ParticipantInActivityOrAssociation.
+     * @return A ParticipantInActivityOrAssociation instance.
+     */
+    public static ParticipantInActivityOrAssociation createParticipantInActivityOrAssociation(final String id) {
+        final ParticipantInActivityOrAssociation result = SpatioTemporalExtentServices
+                .createParticipantInActivityOrAssociation(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PARTICIPANT_IN_ACTIVITY_OR_ASSOCIATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link Party} with an String.
+     *
+     * @param id ID of the Party.
+     * @return A Party instance.
+     */
+    public static Party createParty(final String id) {
+        final Party result = SpatioTemporalExtentServices.createParty(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PARTY);
+        return result;
+    }
+
+    /**
+     * Create a {@link Pattern} with an String.
+     *
+     * @param id ID of the Pattern.
+     * @return A Pattern instance.
+     */
+    public static Pattern createPattern(final String id) {
+        final Pattern result = SpatioTemporalExtentServices.createPattern(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PATTERN);
+        return result;
+    }
+
+    /**
+     * Create a {@link PeriodOfTime} with an String.
+     *
+     * @param id ID of the PeriodOfTime.
+     * @return A PeriodOfTime instance.
+     */
+    public static PeriodOfTime createPeriodOfTime(final String id) {
+        final PeriodOfTime result = SpatioTemporalExtentServices.createPeriodOfTime(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PERIOD_OF_TIME);
+        return result;
+    }
+
+    /**
+     * Create a {@link Person} with an String.
+     *
+     * @param id ID of the Person.
+     * @return A Person instance.
+     */
+    public static Person createPerson(final String id) {
+        final Person result = SpatioTemporalExtentServices.createPerson(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PERSON);
+        return result;
+    }
+
+    /**
+     * Create a {@link PersonInPosition} with an String.
+     *
+     * @param id ID of the PersonInPosition.
+     * @return A PersonInPosition instance.
+     */
+    public static PersonInPosition createPersonInPosition(final String id) {
+        final PersonInPosition result = SpatioTemporalExtentServices.createPersonInPosition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PERSON_IN_POSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link PhysicalObject} with an String.
+     *
+     * @param id ID of the PhysicalObject.
+     * @return A PhysicalObject instance.
+     */
+    public static PhysicalObject createPhysicalObject(final String id) {
+        final PhysicalObject result = SpatioTemporalExtentServices.createPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link PhysicalProperty} with an String.
+     *
+     * @param id ID of the PhysicalProperty.
+     * @return A PhysicalProperty instance.
+     */
+    public static PhysicalProperty createPhysicalProperty(final String id) {
+        final PhysicalProperty result = SpatioTemporalExtentServices.createPhysicalProperty(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PHYSICAL_PROPERTY);
+        return result;
+    }
+
+    /**
+     * Create a {@link PhysicalPropertyRange} with an String.
+     *
+     * @param id ID of the PhysicalPropertyRange.
+     * @return A PhysicalPropertyRange instance.
+     */
+    public static PhysicalPropertyRange createPhysicalPropertyRange(final String id) {
+        final PhysicalPropertyRange result = SpatioTemporalExtentServices.createPhysicalPropertyRange(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PHYSICAL_PROPERTY_RANGE);
+        return result;
+    }
+
+    /**
+     * Create a {@link PhysicalQuantity} with an String.
+     *
+     * @param id ID of the PhysicalQuantity.
+     * @return A PhysicalQuantity instance.
+     */
+    public static PhysicalQuantity createPhysicalQuantity(final String id) {
+        final PhysicalQuantity result = SpatioTemporalExtentServices.createPhysicalQuantity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PHYSICAL_QUANTITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link PhysicalQuantityRange} with an String.
+     *
+     * @param id ID of the PhysicalQuantityRange.
+     * @return A PhysicalQuantityRange instance.
+     */
+    public static PhysicalQuantityRange createPhysicalQuantityRange(final String id) {
+        final PhysicalQuantityRange result = SpatioTemporalExtentServices.createPhysicalQuantityRange(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PHYSICAL_QUANTITY_RANGE);
+        return result;
+    }
+
+    /**
+     * Create a {@link Plan} with an String.
+     *
+     * @param id ID of the Plan.
+     * @return A Plan instance.
+     */
+    public static Plan createPlan(final String id) {
+        final Plan result = SpatioTemporalExtentServices.createPlan(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PLAN);
+        return result;
+    }
+
+    /**
+     * Create a {@link PointInTime} with an String.
+     *
+     * @param id ID of the PointInTime.
+     * @return A PointInTime instance.
+     */
+    public static PointInTime createPointInTime(final String id) {
+        final PointInTime result = SpatioTemporalExtentServices.createPointInTime(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.POINT_IN_TIME);
+        return result;
+    }
+
+    /**
+     * Create a {@link Position} with an String.
+     *
+     * @param id ID of the Position.
+     * @return A Position instance.
+     */
+    public static Position createPosition(final String id) {
+        final Position result = SpatioTemporalExtentServices.createPosition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.POSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link PossibleWorld} with an String.
+     *
+     * @param id ID of the PossibleWorld.
+     * @return A PossibleWorld instance.
+     */
+    public static PossibleWorld createPossibleWorld(final String id) {
+        final PossibleWorld result = SpatioTemporalExtentServices.createPossibleWorld(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.POSSIBLE_WORLD);
+        return result;
+    }
+
+    /**
+     * Create a {@link Price} with an String.
+     *
+     * @param id ID of the Price.
+     * @return A Price instance.
+     */
+    public static Price createPrice(final String id) {
+        final Price result = SpatioTemporalExtentServices.createPrice(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PRICE);
+        return result;
+    }
+
+    /**
+     * Create a {@link ProductBrand} with an String.
+     *
+     * @param id ID of the ProductBrand.
+     * @return A ProductBrand instance.
+     */
+    public static ProductBrand createProductBrand(final String id) {
+        final ProductBrand result = SpatioTemporalExtentServices.createProductBrand(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PRODUCT_BRAND);
+        return result;
+    }
+
+    /**
+     * Create a {@link ProductOffering} with an String.
+     *
+     * @param id ID of the ProductOffering.
+     * @return A ProductOffering instance.
+     */
+    public static ProductOffering createProductOffering(final String id) {
+        final ProductOffering result = SpatioTemporalExtentServices.createProductOffering(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.PRODUCT_OFFERING);
+        return result;
+    }
+
+    /**
+     * Create a {@link ReachingAgreement} with an String.
+     *
+     * @param id ID of the ReachingAgreement.
+     * @return A ReachingAgreement instance.
+     */
+    public static ReachingAgreement createReachingAgreement(final String id) {
+        final ReachingAgreement result = SpatioTemporalExtentServices.createReachingAgreement(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.REACHING_AGREEMENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link RecognizingLanguageCommunity} with an String.
+     *
+     * @param id ID of the RecognizingLanguageCommunity.
+     * @return A RecognizingLanguageCommunity instance.
+     */
+    public static RecognizingLanguageCommunity createRecognizingLanguageCommunity(final String id) {
+        final RecognizingLanguageCommunity result = SpatioTemporalExtentServices.createRecognizingLanguageCommunity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.RECOGNIZING_LANGUAGE_COMMUNITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link RepresentationByPattern} with an String.
+     *
+     * @param id ID of the RepresentationByPattern.
+     * @return A RepresentationByPattern instance.
+     */
+    public static RepresentationByPattern createRepresentationByPattern(final String id) {
+        final RepresentationByPattern result = SpatioTemporalExtentServices.createRepresentationByPattern(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.REPRESENTATION_BY_PATTERN);
+        return result;
+    }
+
+    /**
+     * Create a {@link RepresentationBySign} with an String.
+     *
+     * @param id ID of the RepresentationBySign.
+     * @return A RepresentationBySign instance.
+     */
+    public static RepresentationBySign createRepresentationBySign(final String id) {
+        final RepresentationBySign result = SpatioTemporalExtentServices.createRepresentationBySign(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.REPRESENTATION_BY_SIGN);
+        return result;
+    }
+
+    /**
+     * Create a {@link Requirement} with an String.
+     *
+     * @param id ID of the Requirement.
+     * @return A Requirement instance.
+     */
+    public static Requirement createRequirement(final String id) {
+        final Requirement result = SpatioTemporalExtentServices.createRequirement(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.REQUIREMENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link RequirementSpecification} with an String.
+     *
+     * @param id ID of the RequirementSpecification.
+     * @return A RequirementSpecification instance.
+     */
+    public static RequirementSpecification createRequirementSpecification(final String id) {
+        final RequirementSpecification result = SpatioTemporalExtentServices.createRequirementSpecification(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.REQUIREMENT_SPECIFICATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link SaleOfGoods} with an String.
+     *
+     * @param id ID of the SaleOfGoods.
+     * @return A SaleOfGoods instance.
+     */
+    public static SaleOfGoods createSaleOfGoods(final String id) {
+        final SaleOfGoods result = SpatioTemporalExtentServices.createSaleOfGoods(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SALE_OF_GOODS);
+        return result;
+    }
+
+    /**
+     * Create a {@link SalesProduct} with an String.
+     *
+     * @param id ID of the SalesProduct.
+     * @return A SalesProduct instance.
+     */
+    public static SalesProduct createSalesProduct(final String id) {
+        final SalesProduct result = SpatioTemporalExtentServices.createSalesProduct(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SALES_PRODUCT);
+        return result;
+    }
+
+    /**
+     * Create a {@link SalesProductInstance} with an String.
+     *
+     * @param id ID of the SalesProductInstance.
+     * @return A SalesProductInstance instance.
+     */
+    public static SalesProductInstance createSalesProductInstance(final String id) {
+        final SalesProductInstance result = SpatioTemporalExtentServices.createSalesProductInstance(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SALES_PRODUCT_INSTANCE);
+        return result;
+    }
+
+    /**
+     * Create a {@link SalesProductVersion} with an String.
+     *
+     * @param id ID of the SalesProductVersion.
+     * @return A SalesProductVersion instance.
+     */
+    public static SalesProductVersion createSalesProductVersion(final String id) {
+        final SalesProductVersion result = SpatioTemporalExtentServices.createSalesProductVersion(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SALES_PRODUCT_VERSION);
+        return result;
+    }
+
+    /**
+     * Create a {@link Sign} with an String.
+     *
+     * @param id ID of the Sign.
+     * @return A Sign instance.
+     */
+    public static Sign createSign(final String id) {
+        final Sign result = SpatioTemporalExtentServices.createSign(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SIGN);
+        return result;
+    }
+
+    /**
+     * Create a {@link SociallyConstructedActivity} with an String.
+     *
+     * @param id ID of the SociallyConstructedActivity.
+     * @return A SociallyConstructedActivity instance.
+     */
+    public static SociallyConstructedActivity createSociallyConstructedActivity(final String id) {
+        final SociallyConstructedActivity result = SpatioTemporalExtentServices.createSociallyConstructedActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SOCIALLY_CONSTRUCTED_ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link SociallyConstructedObject} with an String.
+     *
+     * @param id ID of the SociallyConstructedObject.
+     * @return A SociallyConstructedObject instance.
+     */
+    public static SociallyConstructedObject createSociallyConstructedObject(final String id) {
+        final SociallyConstructedObject result = SpatioTemporalExtentServices.createSociallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SOCIALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link SpatioTemporalExtent} with an String.
+     *
+     * @param id ID of the SpatioTemporalExtent.
+     * @return A SpatioTemporalExtent instance.
+     */
+    public static SpatioTemporalExtent createSpatioTemporalExtent(final String id) {
+        final SpatioTemporalExtent result = SpatioTemporalExtentServices.createSpatioTemporalExtent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SPATIO_TEMPORAL_EXTENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link State} with an String.
+     *
+     * @param id ID of the State.
+     * @return A State instance.
+     */
+    public static State createState(final String id) {
+        final State result = SpatioTemporalExtentServices.createState(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfActivity} with an String.
+     *
+     * @param id ID of the StateOfActivity.
+     * @return A StateOfActivity instance.
+     */
+    public static StateOfActivity createStateOfActivity(final String id) {
+        final StateOfActivity result = SpatioTemporalExtentServices.createStateOfActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfAmountOfMoney} with an String.
+     *
+     * @param id ID of the StateOfAmountOfMoney.
+     * @return A StateOfAmountOfMoney instance.
+     */
+    public static StateOfAmountOfMoney createStateOfAmountOfMoney(final String id) {
+        final StateOfAmountOfMoney result = SpatioTemporalExtentServices.createStateOfAmountOfMoney(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_AMOUNT_OF_MONEY);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfAssociation} with an String.
+     *
+     * @param id ID of the StateOfAssociation.
+     * @return A StateOfAssociation instance.
+     */
+    public static StateOfAssociation createStateOfAssociation(final String id) {
+        final StateOfAssociation result = SpatioTemporalExtentServices.createStateOfAssociation(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_ASSOCIATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfBiologicalObject} with an String.
+     *
+     * @param id ID of the StateOfBiologicalObject.
+     * @return A StateOfBiologicalObject instance.
+     */
+    public static StateOfBiologicalObject createStateOfBiologicalObject(final String id) {
+        final StateOfBiologicalObject result = SpatioTemporalExtentServices.createStateOfBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfBiologicalSystem} with an String.
+     *
+     * @param id ID of the StateOfBiologicalSystem.
+     * @return A StateOfBiologicalSystem instance.
+     */
+    public static StateOfBiologicalSystem createStateOfBiologicalSystem(final String id) {
+        final StateOfBiologicalSystem result = SpatioTemporalExtentServices.createStateOfBiologicalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_BIOLOGICAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfBiologicalSystemComponent} with an String.
+     *
+     * @param id ID of the StateOfBiologicalSystemComponent.
+     * @return A StateOfBiologicalSystemComponent instance.
+     */
+    public static StateOfBiologicalSystemComponent createStateOfBiologicalSystemComponent(final String id) {
+        final StateOfBiologicalSystemComponent result = SpatioTemporalExtentServices
+                .createStateOfBiologicalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_BIOLOGICAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfFunctionalObject} with an String.
+     *
+     * @param id ID of the StateOfFunctionalObject.
+     * @return A StateOfFunctionalObject instance.
+     */
+    public static StateOfFunctionalObject createStateOfFunctionalObject(final String id) {
+        final StateOfFunctionalObject result = SpatioTemporalExtentServices.createStateOfFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfFunctionalSystem} with an String.
+     *
+     * @param id ID of the StateOfFunctionalSystem.
+     * @return A StateOfFunctionalSystem instance.
+     */
+    public static StateOfFunctionalSystem createStateOfFunctionalSystem(final String id) {
+        final StateOfFunctionalSystem result = SpatioTemporalExtentServices.createStateOfFunctionalSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_FUNCTIONAL_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfFunctionalSystemComponent} with an String.
+     *
+     * @param id ID of the StateOfFunctionalSystemComponent.
+     * @return A StateOfFunctionalSystemComponent instance.
+     */
+    public static StateOfFunctionalSystemComponent createStateOfFunctionalSystemComponent(final String id) {
+        final StateOfFunctionalSystemComponent result = SpatioTemporalExtentServices
+                .createStateOfFunctionalSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_FUNCTIONAL_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfIntentionallyConstructedObject} with an String.
+     *
+     * @param id ID of the StateOfIntentionallyConstructedObject.
+     * @return A StateOfIntentionallyConstructedObject instance.
+     */
+    public static StateOfIntentionallyConstructedObject createStateOfIntentionallyConstructedObject(final String id) {
+        final StateOfIntentionallyConstructedObject result = SpatioTemporalExtentServices
+                .createStateOfIntentionallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_INTENTIONALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfLanguageCommunity} with an String.
+     *
+     * @param id ID of the StateOfLanguageCommunity.
+     * @return A StateOfLanguageCommunity instance.
+     */
+    public static StateOfLanguageCommunity createStateOfLanguageCommunity(final String id) {
+        final StateOfLanguageCommunity result = SpatioTemporalExtentServices.createStateOfLanguageCommunity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_LANGUAGE_COMMUNITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfOrdinaryBiologicalObject} with an String.
+     *
+     * @param id ID of the StateOfOrdinaryBiologicalObject.
+     * @return A StateOfOrdinaryBiologicalObject instance.
+     */
+    public static StateOfOrdinaryBiologicalObject createStateOfOrdinaryBiologicalObject(final String id) {
+        final StateOfOrdinaryBiologicalObject result = SpatioTemporalExtentServices
+                .createStateOfOrdinaryBiologicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_ORDINARY_BIOLOGICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfOrdinaryFunctionalObject} with an String.
+     *
+     * @param id ID of the StateOfOrdinaryFunctionalObject.
+     * @return A StateOfOrdinaryFunctionalObject instance.
+     */
+    public static StateOfOrdinaryFunctionalObject createStateOfOrdinaryFunctionalObject(final String id) {
+        final StateOfOrdinaryFunctionalObject result = SpatioTemporalExtentServices
+                .createStateOfOrdinaryFunctionalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_ORDINARY_FUNCTIONAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfOrdinaryPhysicalObject} with an String.
+     *
+     * @param id ID of the StateOfOrdinaryPhysicalObject.
+     * @return A StateOfOrdinaryPhysicalObject instance.
+     */
+    public static StateOfOrdinaryPhysicalObject createStateOfOrdinaryPhysicalObject(final String id) {
+        final StateOfOrdinaryPhysicalObject result = SpatioTemporalExtentServices
+                .createStateOfOrdinaryPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_ORDINARY_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfOrganization} with an String.
+     *
+     * @param id ID of the StateOfOrganization.
+     * @return A StateOfOrganization instance.
+     */
+    public static StateOfOrganization createStateOfOrganization(final String id) {
+        final StateOfOrganization result = SpatioTemporalExtentServices.createStateOfOrganization(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_ORGANIZATION);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfOrganizationComponent} with an String.
+     *
+     * @param id ID of the StateOfOrganizationComponent.
+     * @return A StateOfOrganizationComponent instance.
+     */
+    public static StateOfOrganizationComponent createStateOfOrganizationComponent(final String id) {
+        final StateOfOrganizationComponent result = SpatioTemporalExtentServices.createStateOfOrganizationComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_ORGANIZATION_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfParty} with an String.
+     *
+     * @param id ID of the StateOfParty.
+     * @return A StateOfParty instance.
+     */
+    public static StateOfParty createStateOfParty(final String id) {
+        final StateOfParty result = SpatioTemporalExtentServices.createStateOfParty(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_PARTY);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfPerson} with an String.
+     *
+     * @param id ID of the StateOfPerson.
+     * @return A StateOfPerson instance.
+     */
+    public static StateOfPerson createStateOfPerson(final String id) {
+        final StateOfPerson result = SpatioTemporalExtentServices.createStateOfPerson(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_PERSON);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfPhysicalObject} with an String.
+     *
+     * @param id ID of the StateOfPhysicalObject.
+     * @return A StateOfPhysicalObject instance.
+     */
+    public static StateOfPhysicalObject createStateOfPhysicalObject(final String id) {
+        final StateOfPhysicalObject result = SpatioTemporalExtentServices.createStateOfPhysicalObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_PHYSICAL_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfPosition} with an String.
+     *
+     * @param id ID of the StateOfPosition.
+     * @return A StateOfPosition instance.
+     */
+    public static StateOfPosition createStateOfPosition(final String id) {
+        final StateOfPosition result = SpatioTemporalExtentServices.createStateOfPosition(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_POSITION);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfSalesProductInstance} with an String.
+     *
+     * @param id ID of the StateOfSalesProductInstance.
+     * @return A StateOfSalesProductInstance instance.
+     */
+    public static StateOfSalesProductInstance createStateOfSalesProductInstance(final String id) {
+        final StateOfSalesProductInstance result = SpatioTemporalExtentServices.createStateOfSalesProductInstance(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_SALES_PRODUCT_INSTANCE);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfSign} with an String.
+     *
+     * @param id ID of the StateOfSign.
+     * @return A StateOfSign instance.
+     */
+    public static StateOfSign createStateOfSign(final String id) {
+        final StateOfSign result = SpatioTemporalExtentServices.createStateOfSign(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_SIGN);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfSociallyConstructedActivity} with an String.
+     *
+     * @param id ID of the StateOfSociallyConstructedActivity.
+     * @return A StateOfSociallyConstructedActivity instance.
+     */
+    public static StateOfSociallyConstructedActivity createStateOfSociallyConstructedActivity(final String id) {
+        final StateOfSociallyConstructedActivity result = SpatioTemporalExtentServices
+                .createStateOfSociallyConstructedActivity(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_SOCIALLY_CONSTRUCTED_ACTIVITY);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfSociallyConstructedObject} with an String.
+     *
+     * @param id ID of the StateOfSociallyConstructedObject.
+     * @return A StateOfSociallyConstructedObject instance.
+     */
+    public static StateOfSociallyConstructedObject createStateOfSociallyConstructedObject(final String id) {
+        final StateOfSociallyConstructedObject result = SpatioTemporalExtentServices
+                .createStateOfSociallyConstructedObject(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_SOCIALLY_CONSTRUCTED_OBJECT);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfSystem} with an String.
+     *
+     * @param id ID of the StateOfSystem.
+     * @return A StateOfSystem instance.
+     */
+    public static StateOfSystem createStateOfSystem(final String id) {
+        final StateOfSystem result = SpatioTemporalExtentServices.createStateOfSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link StateOfSystemComponent} with an String.
+     *
+     * @param id ID of the StateOfSystemComponent.
+     * @return A StateOfSystemComponent instance.
+     */
+    public static StateOfSystemComponent createStateOfSystemComponent(final String id) {
+        final StateOfSystemComponent result = SpatioTemporalExtentServices.createStateOfSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.STATE_OF_SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link uk.gov.gchq.magmacore.hqdm.model.System} with an String.
+     *
+     * @param id ID of the System.
+     * @return A System instance.
+     */
+    public static uk.gov.gchq.magmacore.hqdm.model.System createSystem(final String id) {
+        final uk.gov.gchq.magmacore.hqdm.model.System result = SpatioTemporalExtentServices.createSystem(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SYSTEM);
+        return result;
+    }
+
+    /**
+     * Create a {@link SystemComponent} with an String.
+     *
+     * @param id ID of the SystemComponent.
+     * @return A SystemComponent instance.
+     */
+    public static SystemComponent createSystemComponent(final String id) {
+        final SystemComponent result = SpatioTemporalExtentServices.createSystemComponent(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.SYSTEM_COMPONENT);
+        return result;
+    }
+
+    /**
+     * Create a {@link Thing} with an String.
+     *
+     * @param id ID of the Thing.
+     * @return A Thing instance.
+     */
+    public static Thing createThing(final String id) {
+        final Thing result = SpatioTemporalExtentServices.createThing(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.THING);
+        return result;
+    }
+
+    /**
+     * Create a {@link TransferOfOwnership} with an String.
+     *
+     * @param id ID of the TransferOfOwnership.
+     * @return A TransferOfOwnership instance.
+     */
+    public static TransferOfOwnership createTransferOfOwnership(final String id) {
+        final TransferOfOwnership result = SpatioTemporalExtentServices.createTransferOfOwnership(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.TRANSFER_OF_OWNERSHIP);
+        return result;
+    }
+
+    /**
+     * Create a {@link TransferOfOwnershipOfMoney} with an String.
+     *
+     * @param id ID of the TransferOfOwnershipOfMoney.
+     * @return A TransferOfOwnershipOfMoney instance.
+     */
+    public static TransferOfOwnershipOfMoney createTransferOfOwnershipOfMoney(final String id) {
+        final TransferOfOwnershipOfMoney result = SpatioTemporalExtentServices.createTransferOfOwnershipOfMoney(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.TRANSFER_OF_OWNERSHIP_OF_MONEY);
+        return result;
+    }
+
+    /**
+     * Create a {@link Transferee} with an String.
+     *
+     * @param id ID of the Transferee.
+     * @return A Transferee instance.
+     */
+    public static Transferee createTransferee(final String id) {
+        final Transferee result = SpatioTemporalExtentServices.createTransferee(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.TRANSFEREE);
+        return result;
+    }
+
+    /**
+     * Create a {@link Transferor} with an String.
+     *
+     * @param id ID of the Transferor.
+     * @return A Transferor instance.
+     */
+    public static Transferor createTransferor(final String id) {
+        final Transferor result = SpatioTemporalExtentServices.createTransferor(id);
+        result.addValue(RDFS.RDF_TYPE, HQDM.TRANSFEROR);
+        return result;
+    }
+}

--- a/hqdm-rdf/src/test/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfServicesTest.java
+++ b/hqdm-rdf/src/test/java/uk/gov/gchq/magmacore/hqdm/rdfservices/RdfServicesTest.java
@@ -1,0 +1,61 @@
+package uk.gov.gchq.magmacore.hqdm.rdfservices;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import uk.gov.gchq.magmacore.hqdm.model.Thing;
+import uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS;
+import uk.gov.gchq.magmacore.hqdm.services.SpatioTemporalExtentServices;
+
+/**
+ * Check that all Rdf*Service methods return a {@link Thing} with an RDFS.RDF_TYPE predicate.
+ */
+public class RdfServicesTest {
+
+    /**
+     * Test all of the RDF*Services classes.
+     */
+    @Test
+    public void testRdfClassServices() {
+        testMethods(RdfClassServices.class.getDeclaredMethods());
+        testMethods(RdfSpatioTemporalExtentServices.class.getDeclaredMethods());
+        testMethods(RdfRelationshipServices.class.getDeclaredMethods());
+    }
+
+    /**
+     * Test the array of methods.
+     *
+     * @param methods an array of {@link Method}
+     */
+    private void testMethods(final Method[] methods) {
+
+        final List<Thing> thingsWithoutRdfType = Arrays.stream(methods)
+                .filter(method -> (method.getModifiers() & Modifier.STATIC) > 0)
+                .filter(method -> method.getName().startsWith("create"))
+                .map(method -> {
+                    try {
+                        final var result = method.invoke(null, "id");
+                        assertNotNull(result);
+                        return (Thing) result;
+                    } catch (final Exception ex) {
+                        fail(ex.getMessage());
+                    }
+                    return SpatioTemporalExtentServices.createThing("id");
+                })
+                .filter(thing -> !thing.hasValue(RDFS.RDF_TYPE))
+                .toList();
+
+        assertTrue(thingsWithoutRdfType.isEmpty());
+        if (!thingsWithoutRdfType.isEmpty()) {
+            System.out.println(thingsWithoutRdfType);
+        }
+    }
+}


### PR DESCRIPTION
Added a set of Rdf*Service classes to enforce the correct `rdf:type` value for each `thing` to save library users from having to do it.

Added a test to make sure all static methods return a `Thing` with an `rdf:type` predicate.