### PR TITLE
Replaced 'http://www.semanticweb.org' domain in HQDM IRIs.

### DIFF
--- a/core/src/main/java/uk/gov/gchq/magmacore/service/sparql/MagmaCoreServiceQueries.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/sparql/MagmaCoreServiceQueries.java
@@ -33,7 +33,7 @@ public class MagmaCoreServiceQueries {
      * </p>
      */
     public static final String FIND_BY_SIGN_VALUE_QUERY = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 
@@ -71,7 +71,7 @@ public class MagmaCoreServiceQueries {
      * </p>
      */
     public static final String FIND_PARTICIPANT_DETAILS_QUERY = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
             PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -146,7 +146,7 @@ public class MagmaCoreServiceQueries {
      * </p>
      */
     public static final String FIND_OBJECTS_BY_TYPE_CLASS_AND_SIGN_PATTERN = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
             select distinct *
@@ -231,7 +231,7 @@ public class MagmaCoreServiceQueries {
      * </p>
      */
     public static final String FIND_OBJECTS_BY_TYPE_AND_SIGN_PATTERN = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
             select distinct *
@@ -304,12 +304,11 @@ public class MagmaCoreServiceQueries {
      * Find Individuals with states participating in associations of a specified kind, their roles and
      * signs.
      * <p>
-     * The Kind IRI is needed in 3 places, e.g. String.format(FIND_BY_KIND_OF_ASSOCIATION, iri, iri,
-     * iri).
+     * The Kind IRI is needed in 3 places, e.g. {@code String.format(FIND_BY_KIND_OF_ASSOCIATION, iri, iri, iri)}.
      * </p>
      */
     public static final String FIND_BY_KIND_OF_ASSOCIATION = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             select ?s ?p ?o
             where
@@ -365,7 +364,7 @@ public class MagmaCoreServiceQueries {
      * Find things associated to a given thing by an association of a given kind.
      */
     public static final String FIND_ASSOCIATED = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
 
             select ?s ?p ?o ?start ?finish
@@ -454,7 +453,7 @@ public class MagmaCoreServiceQueries {
      * Search for items whose sign contains some text and are members of a specific class.
      */
     public static final String FIND_MEMBERS_OF_CLASS_BY_PARTIAL_SIGN_CASE_SENSITIVE = """
-                PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+                PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
                 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
                 SELECT distinct ?s ?p ?o ?start ?finish
@@ -647,7 +646,7 @@ public class MagmaCoreServiceQueries {
      * A partial search by sign for entities composed into a whole entity.
      */
     public static final String FIND_MEMBERS_OF_CLASS_BY_COMPOSITION_AND_PARTIAL_SIGN_CASE_SENSITIVE = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
             SELECT distinct ?s ?p ?o ?start ?finish
@@ -749,7 +748,7 @@ public class MagmaCoreServiceQueries {
      * Find the signs for an entity and the pattern and representation by pattern ENTITY_NAMES.
      */
     public static final String FIND_SIGNS_FOR_ENTITY = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
             SELECT distinct ?sign_value ?pattern_name ?rep_by_pattern_name ?start ?finish
@@ -787,7 +786,7 @@ public class MagmaCoreServiceQueries {
      * TODO: Comment.
      */
     public static final String FIND_BY_FIELD_VALUE_AND_CLASS = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
             SELECT ?s ?p ?o

--- a/core/src/main/java/uk/gov/gchq/magmacore/service/verify/DataIntegrityReport.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/verify/DataIntegrityReport.java
@@ -12,7 +12,7 @@ import uk.gov.gchq.magmacore.hqdm.model.Thing;
 public class DataIntegrityReport {
 
     private static final String CHECK_MISSING_DATA_ENTITY_NAME = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
             ?s hqdm:error_missing_entity_name "Should have a data_EntityName.".
@@ -141,7 +141,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_MISSING_PARTICIPANT_ROLES = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
             ?s hqdm:error_participant_with_no_role "Should be a member_of_kind of a role.".
@@ -163,7 +163,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_POSSIBLE_WORLD_MEMBERSHIP = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
             PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
             construct {
@@ -299,7 +299,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_STATE_TEMPORAL_PART_OF = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_temporal_part_of "Should be a temporal_part_of some individual.".
@@ -345,7 +345,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_SIGN_VALUE_ = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_value_ "Should have a value_ for a sign.".
@@ -363,7 +363,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_SIGN_MEMBER_OF_PATTERN = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_member_of_ "Should be a member_of_ of some pattern.".
@@ -381,7 +381,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_REP_BY_PATTERN_CONSISTS_OF_BY_CLASS = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_consists_of_by_class
@@ -399,7 +399,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_REP_BY_SIGN_CONSISTS_OF_COMMUNITY = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_consists_of_ "Should have a consists_of_ from Rep By Sign.".
@@ -416,7 +416,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_REP_BY_SIGN_CONSISTS_OF_SIGN = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_consists_of "Should have a consists_of from Rep By Sign.".
@@ -433,7 +433,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_REP_BY_PATTERN_CONSISTS_OF_IN_MEMBERS = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_consists_of_in_members "Should have a consists_of_in_members from Rep By Pattern.".
@@ -456,7 +456,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_REP_BY_SIGN_REPRESENTS = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_represents "Should have a represents from Rep By Sign.".
@@ -473,7 +473,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_STATE_OF_SIGN_PARTICIPANT_IN = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_sign_participant_in "Should have a participant_in to Rep By Sign.".
@@ -490,7 +490,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_REP_BY_SIGN_MEMBER_OF = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_member_of_ "Should have a member_of_ to Rep By Pattern.".
@@ -507,7 +507,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_REP_BY_SIGN_HAS_SIGN_PARTICIPANT = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_sign "Should have a state_of_sign as a participant_in this Rep By Sign.".
@@ -525,7 +525,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_REP_BY_SIGN_HAS_COMMUNITY_PARTICIPANT = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_community
@@ -544,7 +544,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_ROLE_PART_OF_BY_CLASS_ = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_part_of_by_class_ "Should have a part_of_by_class_ to a kind_of_association.".
@@ -562,7 +562,7 @@ public class DataIntegrityReport {
             """;
 
     private static final String CHECK_ASSOCIATION_MEMBER_OF_KIND = """
-            PREFIX hqdm: <http://www.semanticweb.org/hqdm#>
+            PREFIX hqdm: <https://hqdmtop.github.io/hqdm#>
 
             construct {
               ?s hqdm:error_missing_kind_of_association "Should have a member_of_kind to a kind_of_association.".

--- a/examples/src/main/java/uk/gov/gchq/magmacore/examples/util/DemoUtils.java
+++ b/examples/src/main/java/uk/gov/gchq/magmacore/examples/util/DemoUtils.java
@@ -30,10 +30,10 @@ import uk.gov.gchq.magmacore.service.transformation.DbTransformation;
 public class DemoUtils {
 
     /** IriBase for Reference Data Library. */
-    public static final IriBase REF_BASE = new IriBase("rdl", "http://www.semanticweb.org/magma-core/rdl#");
+    public static final IriBase REF_BASE = new IriBase("rdl", "https://github.com/gchq/MagmaCore/rdl#");
 
     /** IriBase for User data. */
-    public static final IriBase USER_BASE = new IriBase("user", "http://www.semanticweb.org/magma-core/user#");
+    public static final IriBase USER_BASE = new IriBase("user", "https://github.com/gchq/MagmaCore/user#");
 
     /**
      * Populate a {@link MagmaCoreService} database.

--- a/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/iri/HQDM.java
+++ b/hqdm-rdf/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/iri/HQDM.java
@@ -23,7 +23,7 @@ public final class HQDM {
     }
 
     /** HQDM namespace. */
-    public static final IriBase HQDM = new IriBase("hqdm", "http://www.semanticweb.org/hqdm#");
+    public static final IriBase HQDM = new IriBase("hqdm", "https://hqdmtop.github.io/hqdm#");
 
     /** A human-interpretable name for a particular HQDM entity. */
     public static final HqdmIri ENTITY_NAME = new HqdmIri(HQDM, "data_EntityName");

--- a/hqdm-rdf/src/test/java/uk/gov/gchq/magmacore/hqdm/rdf/util/TriplesTest.java
+++ b/hqdm-rdf/src/test/java/uk/gov/gchq/magmacore/hqdm/rdf/util/TriplesTest.java
@@ -31,10 +31,10 @@ import uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS;
 public class TriplesTest {
 
     private static final String EXPECTED1 = """
-            <http://www.semanticweb.org/hqdm#person1> <http://www.semanticweb.org/hqdm#member_of_kind> \"\"\"PERSON_KIND\"\"\"^^<http://www.w3.org/2001/XMLSchema#string>;
-            <http://www.semanticweb.org/hqdm#data_EntityName> <http://www.semanticweb.org/hqdm#person1>;
-            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.semanticweb.org/hqdm#participant>;
-            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.semanticweb.org/hqdm#person>.
+            <https://hqdmtop.github.io/hqdm#person1> <https://hqdmtop.github.io/hqdm#member_of_kind> \"\"\"PERSON_KIND\"\"\"^^<http://www.w3.org/2001/XMLSchema#string>;
+            <https://hqdmtop.github.io/hqdm#data_EntityName> <https://hqdmtop.github.io/hqdm#person1>;
+            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://hqdmtop.github.io/hqdm#participant>;
+            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://hqdmtop.github.io/hqdm#person>.
             """;
 
     /**


### PR DESCRIPTION
- Replaced 'http://www.semanticweb.org' domain in HQDM IRIs with 'https://hqdmtop.github.io'.