### PR TITLE
Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-jdk14</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.6</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -121,7 +121,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.3.3</version>
+            <version>10.6.0</version>
           </dependency>
         </dependencies>
         <executions>
@@ -142,10 +142,30 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.2.5</version>
+                </requireMavenVersion>
+              </rules>    
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
         <configuration>
-            <!-- <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments> -->
+          <tagNameFormat>@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
- Require minimum Maven version of 3.2.5 (default) with maven-enforcer-plugin.
- Added `tagNameFormat` option to maven-release-plugin configuration.

Updated dependencies: 
- org.slf4j/slf4j-jdk14@2.0.6
- com.puppycrawl.tools/checkstyle@10.6.0
- Added: org.apache.maven.plugins/maven-enforcer-plugin@3.1.0