### PR TITLE
Bugfix: RemoteSparqlDatabaseDemo Missing Module Dependency

### DIFF
--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -24,6 +24,7 @@ module uk.gov.gchq.magmacore {
     requires org.apache.jena.rdfconnection;
     requires org.apache.jena.tdb2;
     requires com.fasterxml.jackson.annotation;
+    requires java.net.http;
 
     requires uk.gov.gchq.magmacore.hqdm;
     requires transitive uk.gov.gchq.magmacore.hqdm.rdf;


### PR DESCRIPTION
- Added missing module dependency 'java.net.http' to core for RemoteSparqlDatabaseDemo example.