### PR TITLE
65 expose a sparql query service

### DIFF
--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -28,9 +28,10 @@ module uk.gov.gchq.magmacore {
 
     requires transitive uk.gov.gchq.magmacore.hqdm;
 
-    exports uk.gov.gchq.magmacore.service;
+    exports uk.gov.gchq.magmacore.database.query;
+    exports uk.gov.gchq.magmacore.exception;
     exports uk.gov.gchq.magmacore.service.dto;
     exports uk.gov.gchq.magmacore.service.transformation;
-    exports uk.gov.gchq.magmacore.exception;
+    exports uk.gov.gchq.magmacore.service;
     exports uk.gov.gchq.magmacore.util;
 }

--- a/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
@@ -842,4 +842,14 @@ public class MagmaCoreService {
     public List<Thing> verifyModel() {
         return DataIntegrityReport.verify(database);
     }
+
+    /**
+     * Execute a SELECT query.
+     *
+     * @param query a SELECT query {@link String}
+     * @return a {@link QueryResultList}
+     */
+    public QueryResultList executeQuery(final String query) {
+        return database.executeQuery(query);
+    }
 }


### PR DESCRIPTION
Also added a unit test.

I decided not to expose the `executeConstruct` and `executeUpdate` methods just yet because this change is more about supporting non-canned queries that we can't predict. Ideally all creates and updates should use the existing functionality.