### PR TITLE
169 Improve the MagmaCoreService API

### DIFF
--- a/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
@@ -54,6 +54,20 @@ import uk.gov.gchq.magmacore.service.verify.DataIntegrityReport;
 
 /**
  * Service for interacting with a {@link MagmaCoreDatabase}.
+ *
+ * <p>
+ * Note that Transaction control is manual unless using any of the following:
+ * <ol>
+ * <li>getInTransaction()</li>
+ * <li>runInReadTransaction()</li>
+ * <li>runInWriteTransaction()</li>
+ * <li>exportTtl()</li>
+ * <li>importTtl()</li>
+ * <li>verifyModel()</li>
+ * </ol>
+ *
+ * Nested transactions are not supported.
+ * </p>
  */
 public class MagmaCoreService {
 
@@ -842,4 +856,34 @@ public class MagmaCoreService {
     public List<Thing> verifyModel() {
         return DataIntegrityReport.verify(database);
     }
+
+    /**
+     * Start a transaction in READ mode.
+     */
+    void beginRead() {
+        database.beginRead();
+    }
+
+    /**
+     * Start a transaction in Write mode.
+     */
+    void beginWrite() {
+        database.beginWrite();
+    }
+
+    /**
+     * Commit a transaction - Finish the current transaction and make any changes permanent (if a
+     * "write" transaction).
+     */
+    void commit() {
+        database.commit();
+    }
+
+    /**
+     * Abort a transaction - Finish the transaction and undo any changes (if a "write" transaction).
+     */
+    void abort() {
+        database.abort();
+    }
+
 }

--- a/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
@@ -57,6 +57,7 @@ import uk.gov.gchq.magmacore.service.verify.DataIntegrityReport;
  *
  * <p>
  * Note that Transaction control is manual unless using any of the following:
+ * </p>
  * <ol>
  * <li>getInTransaction()</li>
  * <li>runInReadTransaction()</li>
@@ -65,7 +66,7 @@ import uk.gov.gchq.magmacore.service.verify.DataIntegrityReport;
  * <li>importTtl()</li>
  * <li>verifyModel()</li>
  * </ol>
- *
+ * <p>
  * Nested transactions are not supported so ensure that no transaction is in progress before 
  * using any of the above methods.
  * </p>

--- a/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
@@ -66,7 +66,8 @@ import uk.gov.gchq.magmacore.service.verify.DataIntegrityReport;
  * <li>verifyModel()</li>
  * </ol>
  *
- * Nested transactions are not supported.
+ * Nested transactions are not supported so ensure that no transaction is in progress before 
+ * using any of the above methods.
  * </p>
  */
 public class MagmaCoreService {
@@ -687,6 +688,24 @@ public class MagmaCoreService {
      */
     public void create(final Thing thing) {
         database.create(thing);
+    }
+
+    /**
+     * Delete an entity from the collection.
+     *
+     * @param object Entity to delete.
+     */
+    void delete(final Thing object) {
+        database.delete(object);
+    }
+
+    /**
+     * Apply a set of deletes to the database.
+     *
+     * @param deletes a {@link List} of {@link DbDeleteOperation}
+     */
+    void delete(final List<DbDeleteOperation> deletes) {
+        database.delete(deletes);
     }
 
     /**


### PR DESCRIPTION
- Documented which methods control transactions themselves.
- Added support for manual transaction control.
- Added support for delete operations.
- Decided to leave the finder methods as they are rather than factor them out. They seem like a bit of a mishmash so I can still move them out if it will make the API more coherent, I would just need to find a clean way to do it.