### PR TITLE
HqdmObjectFactory - disallow duplicate interfaces for dynamic proxies.

### DIFF
--- a/hqdm/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/HqdmObjectFactory.java
+++ b/hqdm/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/HqdmObjectFactory.java
@@ -16,6 +16,7 @@ package uk.gov.gchq.magmacore.hqdm.rdf;
 
 import static uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS.RDF_TYPE;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/hqdm/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/HqdmObjectFactory.java
+++ b/hqdm/src/main/java/uk/gov/gchq/magmacore/hqdm/rdf/HqdmObjectFactory.java
@@ -16,7 +16,6 @@ package uk.gov.gchq.magmacore.hqdm.rdf;
 
 import static uk.gov.gchq.magmacore.hqdm.rdf.iri.RDFS.RDF_TYPE;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -107,7 +106,7 @@ public final class HqdmObjectFactory {
      * @return Array of Class.
      */
     private static <T extends Thing> java.lang.Class<T>[] irisToClasses(final Set<IRI> iris) {
-        final List<java.lang.Class<? extends Thing>> classes = new ArrayList<>(3);
+        final Set<java.lang.Class<? extends Thing>> classes = new HashSet<>(3);
 
         // It will be a small list so just iterate it.
         for (final IRI iri : iris) {


### PR DESCRIPTION
Duplicate interfaces aren't allowed when creating dynamic proxy objects, but when using the inference engine there were multiple copies of the `Thing` interface since that is the default if a class isn't found for an rdf:type. I could just remove `Thing` as the default, but the bug would still be there so this a better solution.