### PR TITLE
Added a query-for-things service.

### DIFF
--- a/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
@@ -924,11 +924,17 @@ public class MagmaCoreService {
      * The third column can contain IRIs or primitive values.
      *
      * @param query a SELECT query {@link String}
-     * @return a {@link QueryResultList}
+     * @return a {@link Map} of {@link IRI} to {@link Thing}
      */
-    public Set<Thing> executeQueryForThings(final String query) {
+    public Map<IRI, Thing> executeQueryForThings(final String query) {
         final QueryResultList resultsList = database.executeQuery(query);
+        
         final List<Thing> things = database.toTopObjects(resultsList);
-        return Set.copyOf(things);
+        
+        final Map<IRI, Thing> result = new HashMap<>();
+        
+        things.forEach(t -> result.put(t.getId(), t));
+
+        return result;
     }
 }

--- a/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
+++ b/core/src/main/java/uk/gov/gchq/magmacore/service/MagmaCoreService.java
@@ -915,4 +915,20 @@ public class MagmaCoreService {
     public QueryResultList executeQuery(final String query) {
         return database.executeQuery(query);
     }
+
+    /**
+     * SPARQL queries restricted to having 3 columns for the subject, predicate, and object, with any names but they must be in that order. E.g.
+     * SELECT ?s ?p ?o WHERE {...} order by ?s ?p ?o
+     * The first column must contain entity IDs.
+     * The second column must contain predicates.
+     * The third column can contain IRIs or primitive values.
+     *
+     * @param query a SELECT query {@link String}
+     * @return a {@link QueryResultList}
+     */
+    public Set<Thing> executeQueryForThings(final String query) {
+        final QueryResultList resultsList = database.executeQuery(query);
+        final List<Thing> things = database.toTopObjects(resultsList);
+        return Set.copyOf(things);
+    }
 }

--- a/core/src/test/java/uk/gov/gchq/magmacore/service/MagmaCoreServiceTest.java
+++ b/core/src/test/java/uk/gov/gchq/magmacore/service/MagmaCoreServiceTest.java
@@ -386,4 +386,36 @@ public class MagmaCoreServiceTest {
         assertEquals(1, result.getQueryResults().size());
         assertEquals(5, result.getQueryResults().get(0).getMap().size());
     }
+
+    /**
+     * Check that it is possible to query for a Set of Things.
+     */
+    @Test
+    public void testQueryForThingsSuccess() {
+        // Create an in-memory databse.
+        final MagmaCoreService service = MagmaCoreServiceFactory.createWithJenaDatabase();
+
+        // Populate some arbitrary data.
+        final IRI subj1 = new IRI(TEST_BASE, "subj1");
+        final IRI obj1 = new IRI(TEST_BASE, "obj1");
+
+        new DbChangeSet(
+            List.of(), // no deletes
+            List.of(// Two creates
+                new DbCreateOperation(subj1, HQDM.MEMBER_OF, obj1),
+                new DbCreateOperation(subj1, RDFS.RDF_TYPE, HQDM.PERSON),
+                new DbCreateOperation(obj1, RDFS.RDF_TYPE, HQDM.CLASS_OF_PERSON)
+                )
+        ).apply(service);
+
+        // Query the service by joining the two statements in a single result.
+        final Set<Thing> result = service.executeQueryForThings("SELECT ?s ?p ?o WHERE { ?s ?p ?o}");
+
+        // Verify the result.
+        assertNotNull(result);
+        //
+        // There should be one result record with five columns.
+        assertEquals(2, result.size());
+        result.forEach(t -> assertTrue(t instanceof Thing));
+    }
 }

--- a/core/src/test/java/uk/gov/gchq/magmacore/service/MagmaCoreServiceTest.java
+++ b/core/src/test/java/uk/gov/gchq/magmacore/service/MagmaCoreServiceTest.java
@@ -414,7 +414,6 @@ public class MagmaCoreServiceTest {
 
         // Verify the result.
         assertNotNull(result);
-        //
         // There should be one result record with five columns.
         assertEquals(2, result.size());
         result.values().forEach(t -> assertTrue(t instanceof Thing));

--- a/core/src/test/java/uk/gov/gchq/magmacore/service/MagmaCoreServiceTest.java
+++ b/core/src/test/java/uk/gov/gchq/magmacore/service/MagmaCoreServiceTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Test;
@@ -409,13 +410,13 @@ public class MagmaCoreServiceTest {
         ).apply(service);
 
         // Query the service by joining the two statements in a single result.
-        final Set<Thing> result = service.executeQueryForThings("SELECT ?s ?p ?o WHERE { ?s ?p ?o}");
+        final Map<IRI, Thing> result = service.executeQueryForThings("SELECT ?s ?p ?o WHERE { ?s ?p ?o}");
 
         // Verify the result.
         assertNotNull(result);
         //
         // There should be one result record with five columns.
         assertEquals(2, result.size());
-        result.forEach(t -> assertTrue(t instanceof Thing));
+        result.values().forEach(t -> assertTrue(t instanceof Thing));
     }
 }


### PR DESCRIPTION
It will be quite often the case that SPARQL results will need to be converted to `Things`, so this change adds such a service along with a unit test.